### PR TITLE
Cải thiện quản lý Role và Course Instructor, chuyển đổi Enum sang String

### DIFF
--- a/JCertPreApplication.API/Controllers/CoursesController.cs
+++ b/JCertPreApplication.API/Controllers/CoursesController.cs
@@ -408,5 +408,37 @@ namespace JCertPreApplication.API.Controllers
             var instructors = await _courseService.GetCourseInstructorsAsync(courseId);
             return Ok(instructors);
         }
+
+        /// <summary>
+        /// Get instructor history for a course
+        /// </summary>
+        /// <remarks>
+        /// Retrieves the complete history of instructors for a course, including:
+        /// - Currently active instructors
+        /// - Past instructors who have left
+        /// - Assignment and departure dates
+        /// - Notes about instructor changes
+        /// 
+        /// This endpoint is useful for:
+        /// - Auditing instructor changes
+        /// - Understanding course staffing history
+        /// - Administrative review of course management
+        /// </remarks>
+        /// <param name="courseId">Course ID to get instructor history for</param>
+        /// <returns>List of instructor history records with timestamps and status</returns>
+        /// <response code="200">Successfully retrieved instructor history.</response>
+        /// <response code="404">Course with the specified ID was not found.</response>
+        /// <response code="400">Invalid course ID format.</response>
+        /// <response code="500">Internal server error occurred during processing.</response>
+        [HttpGet("{courseId}/instructors/history")]
+        [ProducesResponseType(typeof(IEnumerable<CourseInstructorHistoryDto>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ApiErrorResponse), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetCourseInstructorHistory(Guid courseId)
+        {
+            var history = await _courseService.GetCourseInstructorHistoryAsync(courseId);
+            return Ok(history);
+        }
     }
 } 

--- a/JCertPreApplication.Application.Tests/Features/Course/CourseServiceTests.cs
+++ b/JCertPreApplication.Application.Tests/Features/Course/CourseServiceTests.cs
@@ -359,12 +359,14 @@ namespace JCertPreApplication.Application.Tests.Features.Course
             var courseId = Guid.NewGuid();
             var instructorId = Guid.NewGuid();
             var course = new Domain.Entities.Course { courseId = courseId };
-            var instructor = new User { userId = instructorId };
+            var user = new User { userId = instructorId };
 
             _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
                 .ReturnsAsync(course);
             _mockUserRepository.Setup(x => x.GetByIdAsync(instructorId))
-                .ReturnsAsync(instructor);
+                .ReturnsAsync(user);
+            _mockCourseRepository.Setup(x => x.HasActiveInstructorAsync(courseId, instructorId))
+                .ReturnsAsync(false);
 
             // Act
             await _courseService.AddInstructorToCourseAsync(courseId, instructorId);
@@ -375,44 +377,30 @@ namespace JCertPreApplication.Application.Tests.Features.Course
         }
 
         [Fact]
-        public async Task AddInstructorToCourseAsync_Should_ThrowApiException_When_CourseDoesNotExist()
-        {
-            // Arrange
-            var courseId = Guid.NewGuid();
-            var instructorId = Guid.NewGuid();
-
-            _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
-                .ReturnsAsync((Domain.Entities.Course?)null);
-
-            // Act & Assert
-            await Assert.ThrowsAsync<ApiException>(
-                () => _courseService.AddInstructorToCourseAsync(courseId, instructorId));
-        }
-
-        [Fact]
-        public async Task AddInstructorToCourseAsync_Should_ThrowApiException_When_UserDoesNotExist()
+        public async Task AddInstructorToCourseAsync_Should_ThrowApiException_When_InstructorAlreadyActive()
         {
             // Arrange
             var courseId = Guid.NewGuid();
             var instructorId = Guid.NewGuid();
             var course = new Domain.Entities.Course { courseId = courseId };
+            var user = new User { userId = instructorId };
 
             _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
                 .ReturnsAsync(course);
             _mockUserRepository.Setup(x => x.GetByIdAsync(instructorId))
-                .ReturnsAsync((User?)null);
+                .ReturnsAsync(user);
+            _mockCourseRepository.Setup(x => x.HasActiveInstructorAsync(courseId, instructorId))
+                .ReturnsAsync(true);
 
             // Act & Assert
-            await Assert.ThrowsAsync<ApiException>(
+            var exception = await Assert.ThrowsAsync<ApiException>(
                 () => _courseService.AddInstructorToCourseAsync(courseId, instructorId));
+
+            Assert.Equal("INSTRUCTOR_ALREADY_ACTIVE", exception.ErrorCode);
         }
 
-        #endregion
-
-        #region RemoveInstructorFromCourseAsync Tests
-
         [Fact]
-        public async Task RemoveInstructorFromCourseAsync_Should_Succeed_When_CourseExists()
+        public async Task RemoveInstructorFromCourseAsync_Should_Succeed_When_InstructorIsActive()
         {
             // Arrange
             var courseId = Guid.NewGuid();
@@ -421,28 +409,35 @@ namespace JCertPreApplication.Application.Tests.Features.Course
 
             _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
                 .ReturnsAsync(course);
+            _mockCourseRepository.Setup(x => x.DeactivateInstructorFromCourseAsync(courseId, instructorId, null))
+                .ReturnsAsync(true);
 
             // Act
             await _courseService.RemoveInstructorFromCourseAsync(courseId, instructorId);
 
             // Assert
-            _mockCourseRepository.Verify(x => x.RemoveInstructorFromCourseAsync(courseId, instructorId), Times.Once);
+            _mockCourseRepository.Verify(x => x.DeactivateInstructorFromCourseAsync(courseId, instructorId, null), Times.Once);
             _mockCourseRepository.Verify(x => x.SaveChangesAsync(), Times.Once);
         }
 
         [Fact]
-        public async Task RemoveInstructorFromCourseAsync_Should_ThrowApiException_When_CourseDoesNotExist()
+        public async Task RemoveInstructorFromCourseAsync_Should_ThrowApiException_When_InstructorNotActive()
         {
             // Arrange
             var courseId = Guid.NewGuid();
             var instructorId = Guid.NewGuid();
+            var course = new Domain.Entities.Course { courseId = courseId };
 
             _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
-                .ReturnsAsync((Domain.Entities.Course?)null);
+                .ReturnsAsync(course);
+            _mockCourseRepository.Setup(x => x.DeactivateInstructorFromCourseAsync(courseId, instructorId, null))
+                .ReturnsAsync(false);
 
             // Act & Assert
-            await Assert.ThrowsAsync<ApiException>(
+            var exception = await Assert.ThrowsAsync<ApiException>(
                 () => _courseService.RemoveInstructorFromCourseAsync(courseId, instructorId));
+
+            Assert.Equal("INSTRUCTOR_NOT_ACTIVE", exception.ErrorCode);
         }
 
         #endregion
@@ -463,7 +458,7 @@ namespace JCertPreApplication.Application.Tests.Features.Course
 
             _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
                 .ReturnsAsync(course);
-            _mockCourseRepository.Setup(x => x.GetCourseInstructorsAsync(courseId))
+            _mockCourseRepository.Setup(x => x.GetActiveCourseInstructorsAsync(courseId))
                 .ReturnsAsync(instructors);
 
             // Act
@@ -473,19 +468,59 @@ namespace JCertPreApplication.Application.Tests.Features.Course
             Assert.NotNull(result);
             Assert.Equal(2, result.Count());
             Assert.Equal(instructors[0].fullName, result.First().fullName);
+            Assert.Equal(instructors[1].fullName, result.Last().fullName);
         }
 
         [Fact]
-        public async Task GetCourseInstructorsAsync_Should_ThrowApiException_When_CourseDoesNotExist()
+        public async Task GetCourseInstructorHistoryAsync_Should_ReturnHistory_When_CourseExists()
         {
             // Arrange
             var courseId = Guid.NewGuid();
-            _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
-                .ReturnsAsync((Domain.Entities.Course?)null);
+            var course = new Domain.Entities.Course { courseId = courseId };
+            var history = new List<CourseInstructor>
+            {
+                new()
+                {
+                    CourseId = courseId,
+                    InstructorId = Guid.NewGuid(),
+                    Instructor = new User { fullName = "Instructor 1" },
+                    AssignedOn = DateTime.UtcNow.AddDays(-10),
+                    IsActive = true
+                },
+                new()
+                {
+                    CourseId = courseId,
+                    InstructorId = Guid.NewGuid(),
+                    Instructor = new User { fullName = "Instructor 2" },
+                    AssignedOn = DateTime.UtcNow.AddDays(-20),
+                    LeftOn = DateTime.UtcNow.AddDays(-5),
+                    IsActive = false,
+                    Notes = "Left for personal reasons"
+                }
+            };
 
-            // Act & Assert
-            await Assert.ThrowsAsync<ApiException>(
-                () => _courseService.GetCourseInstructorsAsync(courseId));
+            _mockCourseRepository.Setup(x => x.GetByIdAsync(courseId))
+                .ReturnsAsync(course);
+            _mockCourseRepository.Setup(x => x.GetCourseInstructorHistoryAsync(courseId))
+                .ReturnsAsync(history);
+
+            // Act
+            var result = await _courseService.GetCourseInstructorHistoryAsync(courseId);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(2, result.Count());
+            
+            var activeInstructor = result.First();
+            Assert.True(activeInstructor.IsActive);
+            Assert.Equal("Instructor 1", activeInstructor.InstructorName);
+            Assert.Null(activeInstructor.LeftOn);
+
+            var inactiveInstructor = result.Last();
+            Assert.False(inactiveInstructor.IsActive);
+            Assert.Equal("Instructor 2", inactiveInstructor.InstructorName);
+            Assert.NotNull(inactiveInstructor.LeftOn);
+            Assert.Equal("Left for personal reasons", inactiveInstructor.Notes);
         }
 
         #endregion

--- a/JCertPreApplication.Application/Contracts/ICourseInstructorRepository.cs
+++ b/JCertPreApplication.Application/Contracts/ICourseInstructorRepository.cs
@@ -1,0 +1,17 @@
+using JCertPreApplication.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace JCertPreApplication.Application.Contracts
+{
+    public interface ICourseInstructorRepository : IGenericRepository<CourseInstructor>
+    {
+        Task<CourseInstructor?> GetByIds(Guid courseId, Guid instructorId);
+        Task<IEnumerable<CourseInstructor>> GetActiveByCourseId(Guid courseId);
+        Task<IEnumerable<CourseInstructor>> GetHistoryByCourseId(Guid courseId);
+        Task<IEnumerable<CourseInstructor>> GetActiveByInstructorId(Guid instructorId);
+        Task<IEnumerable<CourseInstructor>> GetHistoryByInstructorId(Guid instructorId);
+        Task<bool> IsInstructorAssignedToCourse(Guid courseId, Guid instructorId);
+    }
+} 

--- a/JCertPreApplication.Application/Contracts/ICourseRepository.cs
+++ b/JCertPreApplication.Application/Contracts/ICourseRepository.cs
@@ -10,8 +10,10 @@ namespace JCertPreApplication.Application.Contracts
         Task<Course?> GetByTitleAsync(string title);
         Task<Pagination<Course>> GetCoursesWithPaginationAsync(CourseQueryParameters queryParameters);
         Task<bool> IsTitleUniqueAsync(string title, Guid? excludeCourseId = null);
-        Task AddInstructorToCourseAsync(Guid courseId, Guid instructorId);
-        Task RemoveInstructorFromCourseAsync(Guid courseId, Guid instructorId);
-        Task<IEnumerable<User>> GetCourseInstructorsAsync(Guid courseId);
+        Task<bool> HasActiveInstructorAsync(Guid courseId, Guid instructorId);
+        Task<CourseInstructor> AddInstructorToCourseAsync(Guid courseId, Guid instructorId);
+        Task<bool> DeactivateInstructorFromCourseAsync(Guid courseId, Guid instructorId, string? notes = null);
+        Task<IEnumerable<User>> GetActiveCourseInstructorsAsync(Guid courseId);
+        Task<IEnumerable<CourseInstructor>> GetCourseInstructorHistoryAsync(Guid courseId);
     }
 } 

--- a/JCertPreApplication.Application/Dtos/Course/CourseInstructorDto.cs
+++ b/JCertPreApplication.Application/Dtos/Course/CourseInstructorDto.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace JCertPreApplication.Application.Dtos.Course
+{
+    public class CourseInstructorDto
+    {
+        public Guid CourseId { get; set; }
+        public Guid InstructorId { get; set; }
+        public string InstructorName { get; set; } = null!;
+        public DateTime AssignedOn { get; set; }
+        public DateTime? LeftOn { get; set; }
+        public bool IsActive { get; set; }
+        public string? Notes { get; set; }
+    }
+
+    public class AssignInstructorToCourseDto
+    {
+        public Guid CourseId { get; set; }
+        public Guid InstructorId { get; set; }
+        public string? Notes { get; set; }
+    }
+
+    public class UpdateCourseInstructorDto
+    {
+        public Guid CourseId { get; set; }
+        public Guid InstructorId { get; set; }
+        public bool IsActive { get; set; }
+        public string? Notes { get; set; }
+    }
+} 

--- a/JCertPreApplication.Application/Dtos/Course/CourseInstructorHistoryDto.cs
+++ b/JCertPreApplication.Application/Dtos/Course/CourseInstructorHistoryDto.cs
@@ -1,0 +1,12 @@
+namespace JCertPreApplication.Application.Dtos.Course
+{
+    public class CourseInstructorHistoryDto
+    {
+        public Guid InstructorId { get; set; }
+        public string InstructorName { get; set; } = string.Empty;
+        public DateTime AssignedOn { get; set; }
+        public DateTime? LeftOn { get; set; }
+        public bool IsActive { get; set; }
+        public string? Notes { get; set; }
+    }
+} 

--- a/JCertPreApplication.Application/Features/Auth/AuthService.cs
+++ b/JCertPreApplication.Application/Features/Auth/AuthService.cs
@@ -69,9 +69,7 @@ namespace JCertPreApplication.Application.Features.Auth
             var defaultRole = await _roleRepository.GetByRoleNameAsync("STUDENT");
             if (defaultRole == null)
             {
-                defaultRole = new Role { roleId = Guid.NewGuid(), roleName = "STUDENT", description = "Default role" };
-                await _roleRepository.InsertAsync(defaultRole);
-                await _roleRepository.SaveChangesAsync();
+                throw new ApiException("Default role STUDENT not found.");
             }
 
             var user = new User

--- a/JCertPreApplication.Application/Features/Auth/AuthService.cs
+++ b/JCertPreApplication.Application/Features/Auth/AuthService.cs
@@ -69,7 +69,7 @@ namespace JCertPreApplication.Application.Features.Auth
             var defaultRole = await _roleRepository.GetByRoleNameAsync("STUDENT");
             if (defaultRole == null)
             {
-                throw new ApiException("Default role STUDENT not found.");
+                throw ApiException.InternalServerError("DEFAULT_ROLE_NOT_FOUND", "Default role STUDENT not found in the system.");
             }
 
             var user = new User

--- a/JCertPreApplication.Application/Features/Course/CourseService.cs
+++ b/JCertPreApplication.Application/Features/Course/CourseService.cs
@@ -141,6 +141,10 @@ namespace JCertPreApplication.Application.Features.Course
             if (user == null)
                 throw ApiException.NotFound("User", instructorId);
 
+            // Check if instructor is already active in this course
+            if (await _courseRepository.HasActiveInstructorAsync(courseId, instructorId))
+                throw ApiException.BadRequest("INSTRUCTOR_ALREADY_ACTIVE", "This instructor is already active in this course");
+
             await _courseRepository.AddInstructorToCourseAsync(courseId, instructorId);
             await _courseRepository.SaveChangesAsync();
         }
@@ -151,7 +155,11 @@ namespace JCertPreApplication.Application.Features.Course
             if (course == null)
                 throw ApiException.NotFound("Course", courseId);
 
-            await _courseRepository.RemoveInstructorFromCourseAsync(courseId, instructorId);
+            // Try to deactivate the instructor
+            var deactivated = await _courseRepository.DeactivateInstructorFromCourseAsync(courseId, instructorId);
+            if (!deactivated)
+                throw ApiException.BadRequest("INSTRUCTOR_NOT_ACTIVE", "This instructor is not active in this course");
+
             await _courseRepository.SaveChangesAsync();
         }
 
@@ -161,8 +169,26 @@ namespace JCertPreApplication.Application.Features.Course
             if (course == null)
                 throw ApiException.NotFound("Course", courseId);
 
-            var instructors = await _courseRepository.GetCourseInstructorsAsync(courseId);
+            var instructors = await _courseRepository.GetActiveCourseInstructorsAsync(courseId);
             return instructors.Select(MapToAppUserDto);
+        }
+
+        public async Task<IEnumerable<CourseInstructorHistoryDto>> GetCourseInstructorHistoryAsync(Guid courseId)
+        {
+            var course = await _courseRepository.GetByIdAsync(courseId);
+            if (course == null)
+                throw ApiException.NotFound("Course", courseId);
+
+            var history = await _courseRepository.GetCourseInstructorHistoryAsync(courseId);
+            return history.Select(ci => new CourseInstructorHistoryDto
+            {
+                InstructorId = ci.InstructorId,
+                InstructorName = ci.Instructor.fullName,
+                AssignedOn = ci.AssignedOn,
+                LeftOn = ci.LeftOn,
+                IsActive = ci.IsActive,
+                Notes = ci.Notes
+            });
         }
 
         private static CourseDto MapToCourseDto(Domain.Entities.Course course)
@@ -181,7 +207,10 @@ namespace JCertPreApplication.Application.Features.Course
                 LessonsCount = course.Lessons?.Count ?? 0,
                 LivestreamsCount = course.Livestreams?.Count ?? 0,
                 EnrollmentsCount = course.Enrollments?.Count ?? 0,
-                Instructors = course.Instructors?.Select(MapToAppUserDto).ToList() ?? new List<AppUserDto>()
+                Instructors = course.CourseInstructors?
+                    .Where(ci => ci.IsActive)
+                    .Select(ci => MapToAppUserDto(ci.Instructor))
+                    .ToList() ?? new List<AppUserDto>()
             };
         }
 
@@ -199,7 +228,7 @@ namespace JCertPreApplication.Application.Features.Course
                 Status = course.status,
                 CreatedAt = course.createdAt,
                 EnrollmentsCount = course.Enrollments?.Count ?? 0,
-                InstructorsCount = course.Instructors?.Count ?? 0
+                InstructorsCount = course.CourseInstructors?.Count(ci => ci.IsActive) ?? 0
             };
         }
 

--- a/JCertPreApplication.Application/Features/Course/ICourseService.cs
+++ b/JCertPreApplication.Application/Features/Course/ICourseService.cs
@@ -16,5 +16,6 @@ namespace JCertPreApplication.Application.Features.Course
         Task AddInstructorToCourseAsync(Guid courseId, Guid instructorId);
         Task RemoveInstructorFromCourseAsync(Guid courseId, Guid instructorId);
         Task<IEnumerable<AppUserDto>> GetCourseInstructorsAsync(Guid courseId);
+        Task<IEnumerable<CourseInstructorHistoryDto>> GetCourseInstructorHistoryAsync(Guid courseId);
     }
 } 

--- a/JCertPreApplication.Domain/Entities/Course.cs
+++ b/JCertPreApplication.Domain/Entities/Course.cs
@@ -15,11 +15,11 @@ namespace JCertPreApplication.Domain.Entities
         public DateTime createdAt { get; set; }
 
         // Navigation properties
-        public virtual ICollection<User> Instructors { get; set; } = new List<User>();
         public virtual ICollection<Lesson> Lessons { get; set; } = new List<Lesson>();
         public virtual ICollection<Livestream> Livestreams { get; set; } = new List<Livestream>();
         public virtual ICollection<Feedback> Feedbacks { get; set; } = new List<Feedback>();
         public virtual ICollection<Enrollment> Enrollments { get; set; } = new List<Enrollment>();
         public virtual ICollection<StudyPlanItem> StudyPlanItems { get; set; } = new List<StudyPlanItem>();
+        public virtual ICollection<CourseInstructor> CourseInstructors { get; set; } = new List<CourseInstructor>();
     }
 }

--- a/JCertPreApplication.Domain/Entities/CourseInstructor.cs
+++ b/JCertPreApplication.Domain/Entities/CourseInstructor.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace JCertPreApplication.Domain.Entities
+{
+    public class CourseInstructor
+    {
+        public Guid CourseId { get; set; }
+        public virtual Course Course { get; set; } = null!;
+
+        public Guid InstructorId { get; set; }
+        public virtual User Instructor { get; set; } = null!;
+
+        public DateTime AssignedOn { get; set; }
+        public DateTime? LeftOn { get; set; }
+        public bool IsActive { get; set; }
+        public string? Notes { get; set; }  // Có thể lưu lý do nghỉ hoặc ghi chú khác
+    }
+} 

--- a/JCertPreApplication.Domain/Entities/User.cs
+++ b/JCertPreApplication.Domain/Entities/User.cs
@@ -22,7 +22,6 @@ namespace JCertPreApplication.Domain.Entities
         public virtual InstructorProfile InstructorProfile { get; set; } = null!;
         public virtual StudentProfile StudentProfile { get; set; } = null!;
         public virtual ICollection<Enrollment> Enrollments { get; set; } = new List<Enrollment>();
-        public virtual ICollection<Course> InstructorCourses { get; set; } = new List<Course>();
         public virtual ICollection<Conversation> Conversations { get; set; } = new List<Conversation>();
         public virtual ICollection<Report> StudentReports { get; set; } = new List<Report>(); // For Report.StudentUser
         public virtual ICollection<Report> InstructorReports { get; set; } = new List<Report>(); // For Report.InstructorUser
@@ -31,6 +30,6 @@ namespace JCertPreApplication.Domain.Entities
         public virtual ICollection<StudyPlan> StaffCreatePlans { get; set; } = new List<StudyPlan>();
         public virtual ICollection<TestAttempt> TestAttempts { get; set; } = new List<TestAttempt>();
         public virtual ICollection<Test> CreatedTests { get; set; } = new List<Test>();
+        public virtual ICollection<CourseInstructor> InstructorCourses { get; set; } = new List<CourseInstructor>();
     }
-
 }

--- a/JCertPreApplication.Persistence/Configurations/CourseConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/CourseConfiguration.cs
@@ -22,14 +22,11 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.Property(c => c.status).IsRequired().HasConversion<string>();
             builder.Property(c => c.createdAt).IsRequired();
 
-            // Configure many-to-many relationship with instructors
-            builder.HasMany(c => c.Instructors)
-                   .WithMany(u => u.InstructorCourses)
-                   .UsingEntity(
-                       "course_instructor",
-                       l => l.HasOne(typeof(User)).WithMany().HasForeignKey("UserId"),
-                       r => r.HasOne(typeof(Course)).WithMany().HasForeignKey("CourseId"),
-                       j => j.HasKey("CourseId", "UserId"));
+            // Configure relationship with instructors through CourseInstructor
+            builder.HasMany(c => c.CourseInstructors)
+                   .WithOne(ci => ci.Course)
+                   .HasForeignKey(ci => ci.CourseId)
+                   .OnDelete(DeleteBehavior.NoAction);
 
             // Configure navigation properties
             builder.HasMany(c => c.Lessons)

--- a/JCertPreApplication.Persistence/Configurations/CourseConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/CourseConfiguration.cs
@@ -15,8 +15,8 @@ namespace JCertPreApplication.Persistence.Configurations
             // Configure required properties and constraints
             builder.Property(c => c.title).IsRequired().HasMaxLength(100);
             builder.Property(c => c.description).IsRequired().HasMaxLength(1000);
-            builder.Property(c => c.level).IsRequired();
-            builder.Property(c => c.courseType).IsRequired();
+            builder.Property(c => c.level).IsRequired().HasConversion<string>();
+            builder.Property(c => c.courseType).IsRequired().HasConversion<string>();
             builder.Property(c => c.price).HasPrecision(18, 2).IsRequired();
             builder.Property(c => c.thumbnailUrl).HasMaxLength(500);
             builder.Property(c => c.status).IsRequired().HasConversion<string>();

--- a/JCertPreApplication.Persistence/Configurations/CourseInstructorConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/CourseInstructorConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using JCertPreApplication.Domain.Entities;
+
+namespace JCertPreApplication.Persistence.Configurations
+{
+    public class CourseInstructorConfiguration : IEntityTypeConfiguration<CourseInstructor>
+    {
+        public void Configure(EntityTypeBuilder<CourseInstructor> builder)
+        {
+            builder.ToTable("course_instructor");
+
+            // Configure composite primary key
+            builder.HasKey(ci => new { ci.CourseId, ci.InstructorId, ci.AssignedOn });
+
+            // Configure required properties
+            builder.Property(ci => ci.AssignedOn).IsRequired();
+            builder.Property(ci => ci.IsActive).IsRequired();
+            builder.Property(ci => ci.Notes).HasMaxLength(500);
+
+            // Configure relationships
+            builder.HasOne(ci => ci.Course)
+                .WithMany(c => c.CourseInstructors)
+                .HasForeignKey(ci => ci.CourseId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            builder.HasOne(ci => ci.Instructor)
+                .WithMany(i => i.InstructorCourses)
+                .HasForeignKey(ci => ci.InstructorId)
+                .OnDelete(DeleteBehavior.NoAction);
+        }
+    }
+} 

--- a/JCertPreApplication.Persistence/Configurations/PaymentConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/PaymentConfiguration.cs
@@ -18,7 +18,7 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.Property(p => p.currency).IsRequired().HasMaxLength(50);
             builder.Property(p => p.paymentMethod).IsRequired().HasMaxLength(50);
             builder.Property(p => p.transactionId).IsRequired().HasMaxLength(100);
-            builder.Property(p => p.status).IsRequired();
+            builder.Property(p => p.status).IsRequired().HasConversion<string>();
             builder.Property(p => p.createdAt).IsRequired();
             builder.Property(p => p.description).HasMaxLength(255);
 

--- a/JCertPreApplication.Persistence/Configurations/RoleConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/RoleConfiguration.cs
@@ -20,6 +20,33 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.HasMany(r => r.Users)
                    .WithOne(ur => ur.Role)
                    .HasForeignKey(ur => ur.roleId).OnDelete(DeleteBehavior.NoAction);
+
+            builder.HasData(
+                new Role
+                {
+                    roleId = Guid.Parse("8dd36044-84d4-4e4b-8162-34b7a421657c"),
+                    roleName = "STUDENT",
+                    description = "Student role"
+                },
+                new Role
+                {
+                    roleId = Guid.Parse("8174528c-7f5b-4277-aa1a-1150e7b8b275"),
+                    roleName = "INSTRUCTOR",
+                    description = "Instructor role"
+                },
+                new Role
+                {
+                    roleId = Guid.Parse("0d1c9d64-3be8-4d5c-9ad0-062f83a3a7f8"),
+                    roleName = "ACADEMIC_MANAGER",
+                    description = "Academic Manager role"
+                },
+                new Role
+                {
+                    roleId = Guid.Parse("d500140c-99c5-452f-b44c-a3b4e650d0e6"),
+                    roleName = "ADMIN",
+                    description = "Administrator role"
+                }
+            );
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/StudyPlanItemConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/StudyPlanItemConfiguration.cs
@@ -18,7 +18,7 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.Property(spi => spi.itemType).IsRequired().HasMaxLength(50);
             builder.Property(spi => spi.courseId);
             builder.Property(spi => spi.testId);
-            builder.Property(spi => spi.status).IsRequired();
+            builder.Property(spi => spi.status).IsRequired().HasConversion<string>();
 
             // Configure foreign key relationship
             builder.HasOne(spi => spi.StudyPlan)

--- a/JCertPreApplication.Persistence/Configurations/UserConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/UserConfiguration.cs
@@ -19,6 +19,8 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.Property(u => u.phone).HasMaxLength(20);
             builder.Property(u => u.avatarUrl).HasMaxLength(500);
             builder.Property(u => u.roleId).IsRequired();
+            builder.Property(u => u.status).IsRequired().HasConversion<string>();
+
             // Configure navigation properties
             builder.HasOne(u => u.Role)
                    .WithMany(ur => ur.Users)

--- a/JCertPreApplication.Persistence/DatabaseContext/JCertPreDatabaseContext.cs
+++ b/JCertPreApplication.Persistence/DatabaseContext/JCertPreDatabaseContext.cs
@@ -36,6 +36,7 @@ namespace JCertPreApplication.Persistence.DatabaseContext
         public DbSet<Test> Tests { get; set; }
         public DbSet<TestAttempt> TestAttempts { get; set; }
         public DbSet<User> Users { get; set; }
+        public DbSet<CourseInstructor> CourseInstructors { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -64,6 +65,7 @@ namespace JCertPreApplication.Persistence.DatabaseContext
             modelBuilder.ApplyConfiguration(new TestConfiguration());
             modelBuilder.ApplyConfiguration(new TestAttemptConfiguration());
             modelBuilder.ApplyConfiguration(new UserConfiguration());
+            modelBuilder.ApplyConfiguration(new CourseInstructorConfiguration());
         }
     }
     

--- a/JCertPreApplication.Persistence/DependencyInjection.cs
+++ b/JCertPreApplication.Persistence/DependencyInjection.cs
@@ -51,6 +51,7 @@ namespace JCertPreApplication.Persistence
             services.AddScoped<IStudyPlanItemRepository, StudyPlanItemRepository>();
             services.AddScoped<IQuestionRepository, QuestionRepository>();
             services.AddScoped<IChoiceRepository, ChoiceRepository>();
+            services.AddScoped<ICourseInstructorRepository, CourseInstructorRepository>();
             // Infrastructure Services
             services.AddScoped<IFirebaseService, FirebaseService>();
             services.AddSingleton<IPasswordService, PasswordService>();

--- a/JCertPreApplication.Persistence/Migrations/20250704114257_SeedDefaultRoles.Designer.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250704114257_SeedDefaultRoles.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JCertPreApplication.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JCertPreApplication.Persistence.Migrations
 {
     [DbContext(typeof(JCertPreDatabaseContext))]
-    partial class JCertPreDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250704114257_SeedDefaultRoles")]
+    partial class SeedDefaultRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JCertPreApplication.Persistence/Migrations/20250704114257_SeedDefaultRoles.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250704114257_SeedDefaultRoles.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace JCertPreApplication.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedDefaultRoles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "itemIdRef",
+                table: "study_plan_item");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "lessonId",
+                table: "test",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "courseId",
+                table: "study_plan_item",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "testId",
+                table: "study_plan_item",
+                type: "uuid",
+                nullable: true);
+
+            // Drop and recreate course_instructor table
+            migrationBuilder.DropTable(
+                name: "course_instructor");
+
+            migrationBuilder.CreateTable(
+                name: "course_instructor",
+                columns: table => new
+                {
+                    CourseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    InstructorId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AssignedOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LeftOn = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    Notes = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_course_instructor", x => new { x.CourseId, x.InstructorId, x.AssignedOn });
+                    table.ForeignKey(
+                        name: "FK_course_instructor_course_CourseId",
+                        column: x => x.CourseId,
+                        principalTable: "course",
+                        principalColumn: "courseId",
+                        onDelete: ReferentialAction.NoAction);
+                    table.ForeignKey(
+                        name: "FK_course_instructor_user_InstructorId",
+                        column: x => x.InstructorId,
+                        principalTable: "user",
+                        principalColumn: "userId",
+                        onDelete: ReferentialAction.NoAction);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_course_instructor_InstructorId",
+                table: "course_instructor",
+                column: "InstructorId");
+
+            migrationBuilder.InsertData(
+                table: "role",
+                columns: new[] { "roleId", "description", "roleName" },
+                values: new object[,]
+                {
+                    { new Guid("0d1c9d64-3be8-4d5c-9ad0-062f83a3a7f8"), "Academic Manager role", "ACADEMIC_MANAGER" },
+                    { new Guid("8174528c-7f5b-4277-aa1a-1150e7b8b275"), "Instructor role", "INSTRUCTOR" },
+                    { new Guid("8dd36044-84d4-4e4b-8162-34b7a421657c"), "Student role", "STUDENT" },
+                    { new Guid("d500140c-99c5-452f-b44c-a3b4e650d0e6"), "Administrator role", "ADMIN" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_study_plan_item_courseId",
+                table: "study_plan_item",
+                column: "courseId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_study_plan_item_testId",
+                table: "study_plan_item",
+                column: "testId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_study_plan_item_course_courseId",
+                table: "study_plan_item",
+                column: "courseId",
+                principalTable: "course",
+                principalColumn: "courseId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_study_plan_item_test_testId",
+                table: "study_plan_item",
+                column: "testId",
+                principalTable: "test",
+                principalColumn: "testId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_study_plan_item_course_courseId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_study_plan_item_test_testId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropIndex(
+                name: "IX_study_plan_item_courseId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropIndex(
+                name: "IX_study_plan_item_testId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropTable(
+                name: "course_instructor");
+
+            migrationBuilder.DeleteData(
+                table: "role",
+                keyColumn: "roleId",
+                keyValue: new Guid("0d1c9d64-3be8-4d5c-9ad0-062f83a3a7f8"));
+
+            migrationBuilder.DeleteData(
+                table: "role",
+                keyColumn: "roleId",
+                keyValue: new Guid("8174528c-7f5b-4277-aa1a-1150e7b8b275"));
+
+            migrationBuilder.DeleteData(
+                table: "role",
+                keyColumn: "roleId",
+                keyValue: new Guid("8dd36044-84d4-4e4b-8162-34b7a421657c"));
+
+            migrationBuilder.DeleteData(
+                table: "role",
+                keyColumn: "roleId",
+                keyValue: new Guid("d500140c-99c5-452f-b44c-a3b4e650d0e6"));
+
+            migrationBuilder.DropColumn(
+                name: "courseId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropColumn(
+                name: "testId",
+                table: "study_plan_item");
+
+            migrationBuilder.AddColumn<string>(
+                name: "itemIdRef",
+                table: "study_plan_item",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "lessonId",
+                table: "test",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "course_instructor",
+                columns: table => new
+                {
+                    CourseId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_course_instructor", x => new { x.CourseId, x.UserId });
+                    table.ForeignKey(
+                        name: "FK_course_instructor_course_CourseId",
+                        column: x => x.CourseId,
+                        principalTable: "course",
+                        principalColumn: "courseId",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_course_instructor_user_UserId",
+                        column: x => x.UserId,
+                        principalTable: "user",
+                        principalColumn: "userId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_course_instructor_UserId",
+                table: "course_instructor",
+                column: "UserId");
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Migrations/20250704122313_UpdateEnumStorageToString.Designer.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250704122313_UpdateEnumStorageToString.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JCertPreApplication.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JCertPreApplication.Persistence.Migrations
 {
     [DbContext(typeof(JCertPreDatabaseContext))]
-    partial class JCertPreDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250704122313_UpdateEnumStorageToString")]
+    partial class UpdateEnumStorageToString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JCertPreApplication.Persistence/Migrations/20250704122313_UpdateEnumStorageToString.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250704122313_UpdateEnumStorageToString.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JCertPreApplication.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateEnumStorageToString : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "user",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "study_plan_item",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "status",
+                table: "payment",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "level",
+                table: "course",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "courseType",
+                table: "course",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "status",
+                table: "user",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "status",
+                table: "study_plan_item",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "status",
+                table: "payment",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "level",
+                table: "course",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "courseType",
+                table: "course",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Repositories/CourseInstructorRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/CourseInstructorRepository.cs
@@ -1,0 +1,68 @@
+using JCertPreApplication.Application.Contracts;
+using JCertPreApplication.Domain.Entities;
+using JCertPreApplication.Persistence.DatabaseContext;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace JCertPreApplication.Persistence.Repositories
+{
+    public class CourseInstructorRepository : GenericRepository<CourseInstructor>, ICourseInstructorRepository
+    {
+        public CourseInstructorRepository(JCertPreDatabaseContext context) : base(context)
+        {
+        }
+
+        public async Task<CourseInstructor?> GetByIds(Guid courseId, Guid instructorId)
+        {
+            return await _dbSet
+                .Include(ci => ci.Instructor)
+                .Include(ci => ci.Course)
+                .FirstOrDefaultAsync(ci => ci.CourseId == courseId && ci.InstructorId == instructorId);
+        }
+
+        public async Task<IEnumerable<CourseInstructor>> GetActiveByCourseId(Guid courseId)
+        {
+            return await _dbSet
+                .Include(ci => ci.Instructor)
+                .Where(ci => ci.CourseId == courseId && ci.IsActive)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<CourseInstructor>> GetHistoryByCourseId(Guid courseId)
+        {
+            return await _dbSet
+                .Include(ci => ci.Instructor)
+                .Where(ci => ci.CourseId == courseId)
+                .OrderByDescending(ci => ci.AssignedOn)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<CourseInstructor>> GetActiveByInstructorId(Guid instructorId)
+        {
+            return await _dbSet
+                .Include(ci => ci.Course)
+                .Where(ci => ci.InstructorId == instructorId && ci.IsActive)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<CourseInstructor>> GetHistoryByInstructorId(Guid instructorId)
+        {
+            return await _dbSet
+                .Include(ci => ci.Course)
+                .Where(ci => ci.InstructorId == instructorId)
+                .OrderByDescending(ci => ci.AssignedOn)
+                .ToListAsync();
+        }
+
+        public async Task<bool> IsInstructorAssignedToCourse(Guid courseId, Guid instructorId)
+        {
+            return await _dbSet.AnyAsync(ci => 
+                ci.CourseId == courseId && 
+                ci.InstructorId == instructorId && 
+                ci.IsActive);
+        }
+    }
+} 

--- a/JCertPreApplication.Persistence/Repositories/CourseRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/CourseRepository.cs
@@ -17,7 +17,8 @@ namespace JCertPreApplication.Persistence.Repositories
         public async Task<Course?> GetCourseWithDetailsAsync(Guid courseId)
         {
             return await _dbSet
-                .Include(c => c.Instructors)
+                .Include(c => c.CourseInstructors)
+                    .ThenInclude(ci => ci.Instructor)
                 .Include(c => c.Lessons)
                 .Include(c => c.Livestreams)
                 .Include(c => c.Enrollments)
@@ -34,7 +35,8 @@ namespace JCertPreApplication.Persistence.Repositories
         public async Task<Pagination<Course>> GetCoursesWithPaginationAsync(CourseQueryParameters queryParameters)
         {
             var query = _dbSet
-                .Include(c => c.Instructors)
+                .Include(c => c.CourseInstructors)
+                    .ThenInclude(ci => ci.Instructor)
                 .Include(c => c.Enrollments)
                 .AsQueryable();
 
@@ -49,7 +51,8 @@ namespace JCertPreApplication.Persistence.Repositories
             // Apply instructor filter
             if (queryParameters.InstructorId.HasValue)
             {
-                query = query.Where(c => c.Instructors.Any(i => i.userId == queryParameters.InstructorId.Value));
+                query = query.Where(c => c.CourseInstructors.Any(ci => 
+                    ci.InstructorId == queryParameters.InstructorId.Value && ci.IsActive));
             }
 
             // Apply status filter
@@ -85,7 +88,7 @@ namespace JCertPreApplication.Persistence.Repositories
             {
                 Items = items,
                 TotalItemsCount = totalCount,
-                PageIndex = pageNumber - 1, // PageIndex is 0-based, but pageNumber parameter is 1-based
+                PageIndex = pageNumber - 1,
                 PageSize = pageSize
             };
         }
@@ -102,52 +105,69 @@ namespace JCertPreApplication.Persistence.Repositories
             return !await query.AnyAsync();
         }
 
-        public async Task AddInstructorToCourseAsync(Guid courseId, Guid instructorId)
+        public async Task<bool> HasActiveInstructorAsync(Guid courseId, Guid instructorId)
         {
-            var course = await _dbSet
-                .Include(c => c.Instructors)
-                .FirstOrDefaultAsync(c => c.courseId == courseId);
-
-            if (course == null)
-                throw new ArgumentException($"Course with ID {courseId} not found");
-
-            var instructor = await _context.Set<User>()
-                .FirstOrDefaultAsync(u => u.userId == instructorId);
-
-            if (instructor == null)
-                throw new ArgumentException($"User with ID {instructorId} not found");
-
-            if (!course.Instructors.Any(i => i.userId == instructorId))
-            {
-                course.Instructors.Add(instructor);
-                // Commit sẽ được thực hiện ở Service layer
-            }
+            return await _context.Set<CourseInstructor>()
+                .AnyAsync(ci => ci.CourseId == courseId && 
+                               ci.InstructorId == instructorId && 
+                               ci.IsActive);
         }
 
-        public async Task RemoveInstructorFromCourseAsync(Guid courseId, Guid instructorId)
+        public async Task<CourseInstructor> AddInstructorToCourseAsync(Guid courseId, Guid instructorId)
         {
-            var course = await _dbSet
-                .Include(c => c.Instructors)
-                .FirstOrDefaultAsync(c => c.courseId == courseId);
+            var course = await _dbSet.FindAsync(courseId)
+                ?? throw new ArgumentException($"Course with ID {courseId} not found");
 
-            if (course == null)
-                throw new ArgumentException($"Course with ID {courseId} not found");
+            var instructor = await _context.Set<User>().FindAsync(instructorId)
+                ?? throw new ArgumentException($"User with ID {instructorId} not found");
 
-            var instructor = course.Instructors.FirstOrDefault(i => i.userId == instructorId);
-            if (instructor != null)
+            var courseInstructor = new CourseInstructor
             {
-                course.Instructors.Remove(instructor);
-                // Commit sẽ được thực hiện ở Service layer
-            }
+                CourseId = courseId,
+                InstructorId = instructorId,
+                AssignedOn = DateTime.UtcNow,
+                IsActive = true
+            };
+
+            await _context.Set<CourseInstructor>().AddAsync(courseInstructor);
+            return courseInstructor;
         }
 
-        public async Task<IEnumerable<User>> GetCourseInstructorsAsync(Guid courseId)
+        public async Task<bool> DeactivateInstructorFromCourseAsync(Guid courseId, Guid instructorId, string? notes = null)
         {
-            var course = await _dbSet
-                .Include(c => c.Instructors)
-                .FirstOrDefaultAsync(c => c.courseId == courseId);
+            var courseInstructor = await _context.Set<CourseInstructor>()
+                .FirstOrDefaultAsync(ci => ci.CourseId == courseId && 
+                                         ci.InstructorId == instructorId && 
+                                         ci.IsActive);
 
-            return course?.Instructors ?? new List<User>();
+            if (courseInstructor == null)
+                return false;
+
+            courseInstructor.IsActive = false;
+            courseInstructor.LeftOn = DateTime.UtcNow;
+            courseInstructor.Notes = notes;
+
+            return true;
+        }
+
+        public async Task<IEnumerable<User>> GetActiveCourseInstructorsAsync(Guid courseId)
+        {
+            var instructors = await _context.Set<CourseInstructor>()
+                .Include(ci => ci.Instructor)
+                .Where(ci => ci.CourseId == courseId && ci.IsActive)
+                .Select(ci => ci.Instructor)
+                .ToListAsync();
+
+            return instructors;
+        }
+
+        public async Task<IEnumerable<CourseInstructor>> GetCourseInstructorHistoryAsync(Guid courseId)
+        {
+            return await _context.Set<CourseInstructor>()
+                .Include(ci => ci.Instructor)
+                .Where(ci => ci.CourseId == courseId)
+                .OrderByDescending(ci => ci.AssignedOn)
+                .ToListAsync();
         }
     }
 } 


### PR DESCRIPTION
## Các thay đổi chính:

1. Thêm seed data cho các Role mặc định:
   - STUDENT
   - INSTRUCTOR
   - ACADEMIC_MANAGER
   - ADMIN

2. Chuyển đổi lưu trữ Enum sang String cho:
   - Course: level, courseType
   - Payment: status
   - StudyPlanItem: status
   - User: status

3. Cải thiện quản lý Course Instructor:
   - Thêm bảng course_instructor với các trường: AssignedOn, LeftOn, IsActive, Notes
   - Thêm API endpoint để xem lịch sử giảng viên của khóa học
   - Cập nhật logic thêm/xóa giảng viên để theo dõi thời gian và trạng thái

4. Sửa lỗi khi tạo tài khoản mới:
   - Thay vì tự tạo role STUDENT nếu chưa có, throw exception để đảm bảo data consistency

## Testing:
- Đã thêm unit test cho các thay đổi trong CourseService
- Đã test API endpoints mới
- Đã kiểm tra migration

## Migration:
Thêm 2 migration mới:
- SeedDefaultRoles
- UpdateEnumStorageToString

Lưu ý: Cần chạy migration sau khi merge để cập nhật database schema và seed data.