### PR TITLE
refactor: separate internal and public URLs for reverse proxy deployment

### DIFF
--- a/JCertPreApplication.API/Program.cs
+++ b/JCertPreApplication.API/Program.cs
@@ -141,6 +141,7 @@ static void LogEnvironmentVariables(IConfiguration config)
     Console.WriteLine("\n[API Configuration]");
     Console.WriteLine($"Environment: {config["Api:Environment"]}");
     Console.WriteLine($"Urls: {config["Api:Urls"]}");
+    Console.WriteLine($"PublicUrl: {config["Api:PublicUrl"]}");
     Console.WriteLine($"ShowConfigurationStatus: {config["Api:ShowConfigurationStatus"]}");
     
     // CORS Configuration

--- a/JCertPreApplication.Domain/Configuration/ApiConfiguration.cs
+++ b/JCertPreApplication.Domain/Configuration/ApiConfiguration.cs
@@ -5,7 +5,8 @@ namespace JCertPreApplication.Domain.Configuration
         public const string SectionName = "Api";
         
         public string Environment { get; set; } = "Development";
-        public string Urls { get; set; } = "https://localhost:7001;http://localhost:5001";
+        public string Urls { get; set; } = "http://localhost:5001";
+        public string PublicUrl { get; set; } = "http://localhost:5001";
         public bool ShowConfigurationStatus { get; set; } = true;
     }
 } 

--- a/JCertPreApplication.Domain/Configuration/PayOSConfiguration.cs
+++ b/JCertPreApplication.Domain/Configuration/PayOSConfiguration.cs
@@ -10,7 +10,7 @@ public class PayOSConfiguration
     public string ReturnEndpoint { get; set; } = string.Empty;
     public string CancelEndpoint { get; set; } = string.Empty;
     
-    // BaseUrl sẽ được inject từ ApiConfiguration
+    // BaseUrl sẽ được inject từ ApiConfiguration.PublicUrl (external URL for callbacks)
     private string? _baseUrl;
     public string BaseUrl 
     { 

--- a/JCertPreApplication.Persistence/DependencyInjection.cs
+++ b/JCertPreApplication.Persistence/DependencyInjection.cs
@@ -93,16 +93,11 @@ namespace JCertPreApplication.Persistence
             {
                 configuration.GetSection(PayOSConfiguration.SectionName).Bind(payOSConfig);
                 
-                // Inject BaseUrl từ ApiConfiguration
+                // Inject BaseUrl từ ApiConfiguration.PublicUrl cho external callbacks
                 var apiConfig = configuration.GetSection(ApiConfiguration.SectionName).Get<ApiConfiguration>();
-                if (apiConfig != null && !string.IsNullOrEmpty(apiConfig.Urls))
+                if (apiConfig != null && !string.IsNullOrEmpty(apiConfig.PublicUrl))
                 {
-                    // Lấy URL đầu tiên từ danh sách URLs (có thể có nhiều URLs cách nhau bởi ;)
-                    var firstUrl = apiConfig.Urls.Split(';').FirstOrDefault()?.Trim();
-                    if (!string.IsNullOrEmpty(firstUrl))
-                    {
-                        payOSConfig.BaseUrl = firstUrl;
-                    }
+                    payOSConfig.BaseUrl = apiConfig.PublicUrl.TrimEnd('/');
                 }
             });
             
@@ -114,15 +109,11 @@ namespace JCertPreApplication.Persistence
                     throw new ArgumentException("PayOS configuration not found. Please configure PayOS section in appsettings.json");
                 }
                 
-                // Set BaseUrl từ ApiConfiguration
+                // Set BaseUrl từ ApiConfiguration.PublicUrl cho external callbacks
                 var apiConfig = configuration.GetSection(ApiConfiguration.SectionName).Get<ApiConfiguration>();
-                if (apiConfig != null && !string.IsNullOrEmpty(apiConfig.Urls))
+                if (apiConfig != null && !string.IsNullOrEmpty(apiConfig.PublicUrl))
                 {
-                    var firstUrl = apiConfig.Urls.Split(';').FirstOrDefault()?.Trim();
-                    if (!string.IsNullOrEmpty(firstUrl))
-                    {
-                        payOSConfig.BaseUrl = firstUrl;
-                    }
+                    payOSConfig.BaseUrl = apiConfig.PublicUrl.TrimEnd('/');
                 }
                 
                 return new PayOSService(payOSConfig.ClientId, payOSConfig.ApiKey, payOSConfig.ChecksumKey, 

--- a/env.example
+++ b/env.example
@@ -14,6 +14,7 @@ Redis__ConnectionString="localhost:6379"
 # API Configuration
 Api__Environment="Development"
 Api__Urls="http://localhost:5001"
+Api__PublicUrl="http://localhost:5001"
 
 # CORS Configuration
 Cors__AllowedOrigins="http://localhost:3000,https://localhost:3000,http://localhost:5173,https://localhost:5173"


### PR DESCRIPTION
This pull request updates the API configuration to introduce a new `PublicUrl` field, which is now used for external callbacks (such as PayOS) instead of the internal `Urls` field. The changes ensure that external services receive the correct public-facing URL, improving clarity and correctness in configuration handling.

**API Configuration Updates**
* Added `PublicUrl` property to the `ApiConfiguration` class and updated its default value in both the code and `.env.example` file. (`JCertPreApplication.Domain/Configuration/ApiConfiguration.cs`, `env.example`) [[1]](diffhunk://#diff-55eebd54820251199e33c6adcf6875567d1ee658f5d0eb23b9df8b161fe71abcL8-R9) [[2]](diffhunk://#diff-0521255bbda96fd681ef7be9c0d23f04cb3838b3a905ed7f25b041ec34cf547cR17)
* Updated the environment variable logging to display the new `PublicUrl` value. (`JCertPreApplication.API/Program.cs`)

**PayOS Integration Improvements**
* Modified `PayOSConfiguration` to clarify that `BaseUrl` is injected from `ApiConfiguration.PublicUrl` for external callbacks. (`JCertPreApplication.Domain/Configuration/PayOSConfiguration.cs`)
* Updated dependency injection logic to use `ApiConfiguration.PublicUrl` (instead of the first entry in `Urls`) for setting the `BaseUrl` in PayOS configuration, ensuring correct external callback URL usage. (`JCertPreApplication.Persistence/DependencyInjection.cs`) [[1]](diffhunk://#diff-ca85fdd9bec6f45f619369ebd8f89aad261f478733fc42dd2123c3532e89d241L96-R100) [[2]](diffhunk://#diff-ca85fdd9bec6f45f619369ebd8f89aad261f478733fc42dd2123c3532e89d241L117-R116)- Add Api__PublicUrl configuration property to distinguish between:
  * Api__Urls: Internal HTTP binding for Kestrel (behind reverse proxy)
  * Api__PublicUrl: External HTTPS URL for callbacks/webhooks

- Update ApiConfiguration class with PublicUrl property
- Modify PayOS service to use PublicUrl for external callbacks
- Fix HTTPS certificate error when running behind Caddy reverse proxy
- Update logging to display both internal and public URLs
- Update env.example with new configuration

This change allows the application to:
1. Bind internally on HTTP (no SSL certificate needed)
2. Receive external callbacks on correct HTTPS public URL
3. Work properly behind reverse proxy with SSL termination