### PR TITLE
Feat/course status background service

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -76,18 +76,24 @@ This document provides a comprehensive list of all available APIs in the JCertPr
 
 | Method | Endpoint | Description | Parameters |
 |--------|----------|-------------|------------|
-| `GET` | `/` | Gets courses with filtering and pagination | Query: `CourseQueryParameters` |
+| `GET` | `/` | Gets courses with filtering and pagination | Query: `CourseQueryParameters` (supports CourseType: Personal=0, Public=1) |
 | `GET` | `/{id}` | Gets course by ID | Path: `id` (Guid) |
-| `POST` | `/` | Creates a new course | Body: `CreateCourseDto` (multipart/form-data) |
-| `PUT` | `/{id}` | Updates an existing course | Path: `id`, Body: `UpdateCourseDto` (multipart/form-data) |
+| `POST` | `/` | Creates a new course | Body: `CreateCourseDto` (multipart/form-data) - CourseType: Personal=0, Public=1. Uses ThumbnailFile, ThumbnailUrl deprecated |
+| `PUT` | `/{id}` | Updates an existing course | Path: `id`, Body: `UpdateCourseDto` (multipart/form-data) - CourseType can be changed |
 | `DELETE` | `/{id}` | Deletes a course | Path: `id` (Guid) |
-| `PATCH` | `/{id}/status` | Updates course status | Path: `id`, Body: `CourseStatus` |
+| `PATCH` | `/{id}/status` | Updates course status | Path: `id`, Body: `CourseStatus` (Draft, Published, Archived) |
 | `POST` | `/{courseId}/instructors/{instructorId}` | Assigns instructor to course | Path: `courseId`, `instructorId` |
 | `DELETE` | `/{courseId}/instructors/{instructorId}` | Removes instructor from course | Path: `courseId`, `instructorId` |
 | `GET` | `/{courseId}/instructors` | Gets all instructors for a course | Path: `courseId` |
 | `GET` | `/{courseId}/instructors/history` | Gets instructor assignment history | Path: `courseId` |
 | `GET` | `/instructor/{instructorId}` | Gets courses taught by instructor | Path: `instructorId` |
 | `GET` | `/student/{studentId}` | Gets courses enrolled by student | Path: `studentId` |
+
+**CourseType Values:**
+- `Personal = 0`: Personal course for individual learning
+- `Public = 1`: Public course open for public enrollment
+
+**Note:** CreateCourse now only accepts `ThumbnailFile` for image uploads. The `ThumbnailUrl` field has been removed from course creation.
 
 ---
 
@@ -507,9 +513,38 @@ Public endpoints (no authentication required):
 - **File Management**: Supports multiple file types with optimized upload for videos using chunked upload
 - **Test System**: Complete test creation, attempt, and automatic grading system with score summaries
 
+### 🏷️ Enum Values Reference
+
+#### CourseType
+- `Personal = 0`: Personal course for individual learning
+- `Public = 1`: Public course open for public enrollment
+
+#### CourseStatus
+- `Draft`: Course is being developed
+- `Published`: Course is available for enrollment
+- `Archived`: Course is no longer active
+
+#### CourseLevel
+- `N5`: Beginner level
+- `N4`: Elementary level  
+- `N3`: Intermediate level
+- `N2`: Pre-advanced level
+- `N1`: Advanced level
+
+#### TestStatus
+- `Draft`: Test is being developed
+- `Published`: Test is available for attempts
+- `Archived`: Test is no longer active
+
+#### TestType
+- `JLPTAuto`: Automatically generated JLPT test
+- `EntryAuto`: Automatically generated entry test
+- `CustomManual`: Manually created custom test
+- `CustomAuto`: Automatically generated custom test
+
 ---
 
-**Last Updated:** August 2, 2025  
+**Last Updated:** August 5, 2025  
 **API Version:** 1.0  
 **Base URL:** `https://your-api-domain.com`
 
@@ -518,6 +553,12 @@ Public endpoints (no authentication required):
 ## 📊 API Summary
 
 This documentation covers **27 controllers** with a total of **123+ API endpoints** for the JCertPre Japanese Certification Learning Platform:
+
+### Recent Updates (August 5, 2025):
+- **CourseType Enum Updated**: Now supports `Personal (0)` and `Public (1)` values only
+- **Course Creation Enhanced**: Removed deprecated `ThumbnailUrl` field, now uses `ThumbnailFile` exclusively
+- **Swagger Integration**: CourseType enum now displays explicit values in API documentation
+- **Code Cleanup**: Removed unused `MediaType` enum to reduce technical debt
 
 ### Controllers Covered:
 1. **AuthController** - Authentication & authorization (10 endpoints)

--- a/JCertPreApplication.API/Controllers/CoursesController.cs
+++ b/JCertPreApplication.API/Controllers/CoursesController.cs
@@ -10,6 +10,8 @@ namespace JCertPreApplication.API.Controllers
 {
     /// <summary>
     /// Manages course operations and instructor assignments.
+    /// Supports CourseType enum with values: Personal (0), Public (1).
+    /// Uses file upload for thumbnails, ThumbnailUrl is deprecated in create operations.
     /// </summary>
     [Route("api/course")]
     [ApiController]
@@ -27,6 +29,8 @@ namespace JCertPreApplication.API.Controllers
         /// <summary>
         /// Gets courses with filtering and pagination.
         /// </summary>
+        /// <param name="queryParameters">Query parameters for filtering courses by various criteria including CourseType (Personal=0, Public=1)</param>
+        /// <returns>Paginated list of courses</returns>
         [HttpGet]
         public async Task<IActionResult> GetCourses([FromQuery] CourseQueryParameters queryParameters)
         {
@@ -47,6 +51,8 @@ namespace JCertPreApplication.API.Controllers
         /// <summary>
         /// Creates a new course.
         /// </summary>
+        /// <param name="createCourseDto">Course creation data including CourseType (Personal=0, Public=1). Use ThumbnailFile for image upload, ThumbnailUrl is no longer supported.</param>
+        /// <returns>Created course details</returns>
         [HttpPost]
         [Consumes("multipart/form-data")]
         public async Task<IActionResult> CreateCourse([FromForm] CreateCourseDto createCourseDto)
@@ -61,6 +67,9 @@ namespace JCertPreApplication.API.Controllers
         /// <summary>
         /// Updates an existing course.
         /// </summary>
+        /// <param name="id">Course ID to update</param>
+        /// <param name="updateCourseDto">Course update data. CourseType can be changed to Personal=0 or Public=1. Use ThumbnailFile for new image upload.</param>
+        /// <returns>Updated course details</returns>
         [HttpPut("{id}")]
         [Consumes("multipart/form-data")]
         public async Task<IActionResult> UpdateCourse(Guid id, [FromForm] UpdateCourseDto updateCourseDto)
@@ -85,6 +94,9 @@ namespace JCertPreApplication.API.Controllers
         /// <summary>
         /// Updates course status.
         /// </summary>
+        /// <param name="id">Course ID to update</param>
+        /// <param name="status">New course status (Draft, Published, Archived)</param>
+        /// <returns>No content if successful</returns>
         [HttpPatch("{id}/status")]
         public async Task<IActionResult> UpdateCourseStatus(Guid id, [FromBody] CourseStatus status)
         {

--- a/JCertPreApplication.Application/Dtos/Course/CreateCourseDto.cs
+++ b/JCertPreApplication.Application/Dtos/Course/CreateCourseDto.cs
@@ -58,14 +58,6 @@ namespace JCertPreApplication.Application.Dtos.Course
         public IFormFile? ThumbnailFile { get; set; }
 
         /// <summary>
-        /// URL to the course thumbnail image. Optional field.
-        /// This field is deprecated in favor of ThumbnailFile.
-        /// </summary>
-        /// <example>https://cdn.jcertpre.com/thumbnails/n5-course-thumb.jpg</example>
-        [Url(ErrorMessage = "Please provide a valid URL for the thumbnail")]
-        public string? ThumbnailUrl { get; set; }
-
-        /// <summary>
         /// Course start date (UTC).
         /// </summary>
         /// <example>2024-01-20T00:00:00Z</example>

--- a/JCertPreApplication.Domain/Enums/CourseStatus.cs
+++ b/JCertPreApplication.Domain/Enums/CourseStatus.cs
@@ -4,7 +4,6 @@ namespace JCertPreApplication.Domain.Enums
     {
         Draft,
         Published,
-        Archived,
-        Suspended
+        Archived
     }
 } 

--- a/JCertPreApplication.Domain/Enums/CourseType.cs
+++ b/JCertPreApplication.Domain/Enums/CourseType.cs
@@ -2,8 +2,7 @@
 {
     public enum CourseType
     {
-        Learn,
-        Train,
-        LearnAndTrain
+        Personal = 0,
+        Public = 1
     }
 }

--- a/JCertPreApplication.Domain/Enums/MediaType.cs
+++ b/JCertPreApplication.Domain/Enums/MediaType.cs
@@ -1,8 +1,0 @@
-﻿namespace JCertPreApplication.Domain.Enums
-{
-    public enum MediaType
-    {
-        Image,
-        Video
-    }
-}

--- a/JCertPreApplication.Persistence/DependencyInjection.cs
+++ b/JCertPreApplication.Persistence/DependencyInjection.cs
@@ -142,6 +142,7 @@ namespace JCertPreApplication.Persistence
                 provider.GetRequiredService<TestAttemptAutoSubmitService>());
 
             services.AddHostedService<LivestreamStatusBackgroundService>();
+            services.AddHostedService<CourseStatusBackgroundService>();
 
             return services;
         }

--- a/JCertPreApplication.Persistence/Services/BackgroudServices/CourseStatusBackgroundService.cs
+++ b/JCertPreApplication.Persistence/Services/BackgroudServices/CourseStatusBackgroundService.cs
@@ -1,0 +1,83 @@
+using JCertPreApplication.Application.Contracts;
+using JCertPreApplication.Domain.Enums;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace JCertPreApplication.Persistence.Services.BackgroudServices
+{
+    public class CourseStatusBackgroundService : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<CourseStatusBackgroundService> _logger;
+        private readonly TimeSpan _interval = TimeSpan.FromHours(1); // Chạy mỗi giờ
+
+        public CourseStatusBackgroundService(
+            IServiceProvider serviceProvider,
+            ILogger<CourseStatusBackgroundService> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await UpdateExpiredCoursesAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error occurred while updating expired courses");
+                }
+
+                await Task.Delay(_interval, stoppingToken);
+            }
+        }
+
+        private async Task UpdateExpiredCoursesAsync()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var courseRepository = scope.ServiceProvider.GetRequiredService<ICourseRepository>();
+
+            _logger.LogInformation("Starting course status update process at {Time}", DateTime.UtcNow);
+
+            try
+            {
+                // Lấy tất cả courses có status không phải Archived và đã qua endDate
+                var allCourses = await courseRepository.GetAllAsync();
+                var expiredCourses = allCourses
+                    .Where(c => c.status != CourseStatus.Archived && 
+                               DateTime.UtcNow > c.endDate)
+                    .ToList();
+
+                if (expiredCourses.Any())
+                {
+                    _logger.LogInformation("Found {Count} expired courses to archive", expiredCourses.Count);
+
+                    foreach (var course in expiredCourses)
+                    {
+                        course.status = CourseStatus.Archived;
+                        await courseRepository.UpdateAsync(course);
+                        
+                        _logger.LogInformation("Archived course {CourseId} - {Title} (EndDate: {EndDate})", 
+                            course.courseId, course.title, course.endDate);
+                    }
+
+                    _logger.LogInformation("Successfully archived {Count} expired courses", expiredCourses.Count);
+                }
+                else
+                {
+                    _logger.LogInformation("No expired courses found to archive");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while processing expired courses");
+                throw;
+            }
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Services/BackgroudServices/CourseStatusBackgroundService.cs
+++ b/JCertPreApplication.Persistence/Services/BackgroudServices/CourseStatusBackgroundService.cs
@@ -10,7 +10,9 @@ namespace JCertPreApplication.Persistence.Services.BackgroudServices
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<CourseStatusBackgroundService> _logger;
-        private readonly TimeSpan _interval = TimeSpan.FromHours(1); // Chạy mỗi giờ
+        //private readonly TimeSpan _interval = TimeSpan.FromHours(1); // Chạy mỗi giờ
+        private readonly TimeSpan _interval = TimeSpan.FromMinutes(2); // Chạy mỗi 2 phút
+
 
         public CourseStatusBackgroundService(
             IServiceProvider serviceProvider,
@@ -66,6 +68,8 @@ namespace JCertPreApplication.Persistence.Services.BackgroudServices
                             course.courseId, course.title, course.endDate);
                     }
 
+                    // Save changes to database
+                    await courseRepository.SaveChangesAsync();
                     _logger.LogInformation("Successfully archived {Count} expired courses", expiredCourses.Count);
                 }
                 else


### PR DESCRIPTION
This pull request introduces several important updates to the course management APIs and related backend logic, focusing on simplifying the course type and status enums, improving documentation, and automating course archival. The most significant changes include refactoring the `CourseType` and `CourseStatus` enums, deprecating the `ThumbnailUrl` field in favor of file uploads, adding a background service to automatically archive expired courses, and updating API documentation for clarity and accuracy.

### API and Enum Refactoring

* **CourseType Enum Simplified:** The `CourseType` enum now only supports `Personal = 0` and `Public = 1`, removing previous values (`Learn`, `Train`, `LearnAndTrain`). This change is reflected throughout the API documentation and controller XML comments. [[1]](diffhunk://#diff-807ef74ba5b5260ef3557070a321203a3ced51b0d4e0030efa320de2dce9b855L5-R6) [[2]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39L79-R97) [[3]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R13-R14) [[4]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R32-R33)
* **CourseStatus Enum Updated:** The `Suspended` status has been removed from the `CourseStatus` enum; only `Draft`, `Published`, and `Archived` remain. [[1]](diffhunk://#diff-3bef50a5b12a6e8e960d64468516b73dd6d23455607ae37ad23438a30ebf8bcbL7-R7) [[2]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39L79-R97) [[3]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39R516-R547)

### API Documentation and Controller Improvements

* **API Documentation Enhanced:** The documentation now includes explicit enum value references, updated descriptions for endpoints, and a new section listing all relevant enum values. Deprecated fields and new behaviors are clearly marked. [[1]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39L79-R97) [[2]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39R516-R547) [[3]](diffhunk://#diff-aeec93da9815469b242a72672585fa0ad0ff87cc1c37f2c4a5f113fae26d3f39R557-R562)
* **Controller XML Comments Updated:** All relevant controller actions now have detailed XML comments describing enum usage and clarifying that only file uploads are accepted for thumbnails. [[1]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R13-R14) [[2]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R32-R33) [[3]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R54-R55) [[4]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R70-R72) [[5]](diffhunk://#diff-c7db46bc2b528f9556222619d313c50552d3be5df58175cb9d773bf399d4b1e6R97-R99)

### Backend Logic and Technical Debt Reduction

* **Automatic Course Archival:** A new background service (`CourseStatusBackgroundService`) periodically checks for expired courses (end date passed, not already archived) and updates their status to `Archived`. This service is registered in dependency injection. [[1]](diffhunk://#diff-ca85fdd9bec6f45f619369ebd8f89aad261f478733fc42dd2123c3532e89d241R145) [[2]](diffhunk://#diff-e0aab9b512eebf9a9457da27f0f0f6d6fde9d6e22e306dbddfcefa4dccc821a5R1-R87)
* **Deprecated and Unused Code Removed:** The deprecated `ThumbnailUrl` field has been removed from the `CreateCourseDto`, and the unused `MediaType` enum has been deleted from the codebase. [[1]](diffhunk://#diff-f8478e608e4209543c40429be56b06093f2b4c53d2c86ce23cbb526940d31f4fL60-L67) [[2]](diffhunk://#diff-e84f306ed3b6f1d098977da1a114df331f8ba2eb4a4af2a0dadc941a677c9c7cL1-L8)