### PR TITLE
feat: import json for question

### DIFF
--- a/JCertPreApplication.API/Controllers/QuestionController.cs
+++ b/JCertPreApplication.API/Controllers/QuestionController.cs
@@ -119,5 +119,36 @@ public async Task<IActionResult> GetPagingActiveWithDetails(
     var dto = await _questionService.GetPaginatedActiveWithDetailsAsync(search, pageIndex, pageSize, contentName, level, subContentName, difficulty);
     return Ok(dto);
 }
+
+[HttpPost("import")]
+[Consumes("multipart/form-data")]
+public async Task<IActionResult> ImportQuestions([FromForm] ImportQuestionsRequestDto dto)
+{
+    if (!ModelState.IsValid)
+        return BadRequest(ModelState);
+
+    var result = await _questionService.ImportQuestionsAsync(dto);
+
+    if (result.FailedCount > 0 && !string.IsNullOrEmpty(result.FailedFileUrl))
+    {
+        var fileBytes = await System.IO.File.ReadAllBytesAsync(Path.Combine(Path.GetTempPath(), result.FailedFileUrl));
+        System.IO.File.Delete(Path.Combine(Path.GetTempPath(), result.FailedFileUrl));
+
+        // Add summary info to response headers
+        Response.Headers.Append("X-Total-Count", result.TotalCount.ToString());
+        Response.Headers.Append("X-Success-Count", result.SuccessCount.ToString());
+        Response.Headers.Append("X-Failed-Count", result.FailedCount.ToString());
+
+        return File(fileBytes, "application/json", "import_failed.json");
+    }
+
+    // No failed questions, return summary as JSON
+    return Ok(new
+    {
+        totalCount = result.TotalCount,
+        successCount = result.SuccessCount,
+        failedCount = result.FailedCount
+    });
+}
 }
 }

--- a/JCertPreApplication.Application/Dtos/Question/ImportQuestionJsonDto.cs
+++ b/JCertPreApplication.Application/Dtos/Question/ImportQuestionJsonDto.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using JCertPreApplication.Domain.Enums;
+
+namespace JCertPreApplication.Application.Dtos.Question
+{
+    public class ImportQuestionJsonDto
+    {
+        public string Content { get; set; } = string.Empty;
+        public string? Explanation { get; set; }
+        public int Points { get; set; }
+        public QuestionDifficulty Difficulty { get; set; }
+        public bool IsActive { get; set; }
+        public ContentName ContentName { get; set; }
+        public CourseLevel Level { get; set; }
+        public SubContentName SubContentName { get; set; }
+        public List<ImportChoiceJsonDto> Choices { get; set; } = new();
+    }
+
+    public class ImportChoiceJsonDto
+    {
+        public string Content { get; set; } = string.Empty;
+        public bool IsCorrect { get; set; }
+    }
+}

--- a/JCertPreApplication.Application/Dtos/Question/ImportQuestionsRequestDto.cs
+++ b/JCertPreApplication.Application/Dtos/Question/ImportQuestionsRequestDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace JCertPreApplication.Application.Dtos.Question
+{
+    public class ImportQuestionsRequestDto
+    {
+        public IFormFile File { get; set; } = null!;
+    }
+}

--- a/JCertPreApplication.Application/Dtos/Question/ImportQuestionsResultDto.cs
+++ b/JCertPreApplication.Application/Dtos/Question/ImportQuestionsResultDto.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace JCertPreApplication.Application.Dtos.Question
+{
+    public class ImportQuestionsResultDto
+    {
+        public int TotalCount { get; set; }
+        public int SuccessCount { get; set; }
+        public int FailedCount { get; set; }
+        public List<ImportQuestionErrorDto> FailedQuestions { get; set; } = new();
+        public string? FailedFileUrl { get; set; }
+    }
+
+    public class ImportQuestionErrorDto
+    {
+        public string QuestionText { get; set; } = string.Empty;
+        public string Error { get; set; } = string.Empty;
+    }
+}

--- a/JCertPreApplication.Application/Dtos/Question/example.json
+++ b/JCertPreApplication.Application/Dtos/Question/example.json
@@ -1,0 +1,70 @@
+[
+  {
+    "Content": "What is the capital of France?",
+    "Explanation": "Paris is the capital city.",
+    "Points": 5,
+    "Difficulty": 1,
+    "IsActive": true,
+    "ContentName": 0, 
+    "Level": 0,
+    "SubContentName": 0, 
+    "Choices": [
+      {
+        "Content": "Paris",
+        "IsCorrect": true
+      },
+      {
+        "Content": "London",
+        "IsCorrect": false
+      },
+      {
+        "Content": "Berlin",
+        "IsCorrect": false
+      }
+    ]
+  },
+  {
+    "Content": "Which planet is known as the Red Planet?",
+    "Explanation": "Mars is called the Red Planet.",
+    "Points": 5,
+    "Difficulty": 2,
+    "IsActive": true,
+    "ContentName": 0,
+    "Level": 0,
+    "SubContentName": 0,
+    "Choices": [
+      {
+        "Content": "Mars",
+        "IsCorrect": true
+      },
+      {
+        "Content": "Venus",
+        "IsCorrect": false
+      },
+      {
+        "Content": "Jupiter",
+        "IsCorrect": false
+      }
+    ]
+  },
+  {
+    "Content": "This will fail because it's Listening type.",
+    "Explanation": "Listening import is not supported.",
+    "Points": 5,
+    "Difficulty": 1,
+    "IsActive": true,
+    "ContentName": 2, 
+    "Level": 0,
+    "SubContentName": 0,
+    "Choices": [
+      {
+        "Content": "A",
+        "IsCorrect": true
+      },
+      {
+        "Content": "B",
+        "IsCorrect": false
+      }
+    ]
+  }
+]

--- a/JCertPreApplication.Application/Features/Questions/IQuestionService.cs
+++ b/JCertPreApplication.Application/Features/Questions/IQuestionService.cs
@@ -3,6 +3,7 @@ using JCertPreApplication.Application.Utilities;
 using JCertPreApplication.Domain.Entities;
 using JCertPreApplication.Domain.Enums;
 using System;
+using System.Threading.Tasks;
 
 namespace JCertPreApplication.Application.Features.Questions
 {
@@ -31,5 +32,6 @@ namespace JCertPreApplication.Application.Features.Questions
             QuestionDifficulty? difficulty = null
 );
         Task<QuestionForTestDto?> GetByIdForTestAsync(Guid id);
+        Task<ImportQuestionsResultDto> ImportQuestionsAsync(ImportQuestionsRequestDto dto);
     }
 }

--- a/JCertPreApplication.Application/Features/Questions/QuestionService.cs
+++ b/JCertPreApplication.Application/Features/Questions/QuestionService.cs
@@ -7,6 +7,8 @@ using JCertPreApplication.Domain.Entities;
 using JCertPreApplication.Domain.Enums;
 using Microsoft.AspNetCore.Http;
 using System.Linq.Expressions;
+using System.Text.Json;
+using System.IO;
 
 namespace JCertPreApplication.Application.Features.Questions
 {
@@ -19,17 +21,20 @@ namespace JCertPreApplication.Application.Features.Questions
         private readonly IQuestionRepository _questionRepository;
         private readonly ISubContentRepository _subContentRepository;
         private readonly IQuestionAttachmentRepository _questionAttachmentRepository;
+        private readonly IChoiceRepository _choiceRepository;
         private readonly IFileService _fileService;
 
         public QuestionService(
             IQuestionRepository questionRepository,
             ISubContentRepository subContentRepository,
             IQuestionAttachmentRepository questionAttachmentRepository,
+            IChoiceRepository choiceRepository,
             IFileService fileService)
         {
             _questionRepository = questionRepository ?? throw new ArgumentNullException(nameof(questionRepository));
             _subContentRepository = subContentRepository ?? throw new ArgumentNullException(nameof(subContentRepository));
             _questionAttachmentRepository = questionAttachmentRepository ?? throw new ArgumentNullException(nameof(questionAttachmentRepository));
+            _choiceRepository = choiceRepository ?? throw new ArgumentNullException(nameof(choiceRepository));
             _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         }
 
@@ -433,6 +438,130 @@ namespace JCertPreApplication.Application.Features.Questions
             catch (Exception ex)
             {
                 throw ApiException.InternalServerError("QUESTION_SERVICE_ERROR", $"An error occurred while retrieving active paginated questions: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Imports questions from a JSON file. Supports batch import with error reporting.
+        /// </summary>
+        public async Task<ImportQuestionsResultDto> ImportQuestionsAsync(ImportQuestionsRequestDto dto)
+        {
+            var result = new ImportQuestionsResultDto();
+            var failedList = new List<ImportQuestionErrorDto>();
+            int success = 0, failed = 0, total = 0;
+
+            try
+            {
+                if (dto.File == null || dto.File.Length == 0)
+                    throw ApiException.BadRequest("IMPORT_FILE_EMPTY", "No file uploaded.");
+
+                List<ImportQuestionJsonDto>? questions;
+                using (var stream = dto.File.OpenReadStream())
+                {
+                    questions = await JsonSerializer.DeserializeAsync<List<ImportQuestionJsonDto>>(stream, new JsonSerializerOptions
+                    {
+                        PropertyNameCaseInsensitive = true
+                    });
+                }
+
+                if (questions == null)
+                    throw ApiException.BadRequest("IMPORT_FILE_INVALID", "File content is invalid or empty.");
+
+                total = questions.Count;
+
+                foreach (var q in questions)
+                {
+                    try
+                    {
+                        // Skip Listening questions
+                        if (q.ContentName == ContentName.Listening)
+                            throw new Exception("Importing Listening questions is not supported.");
+
+                        // Validate required fields
+                        if (string.IsNullOrWhiteSpace(q.Content) || q.Content.Length < 10)
+                            throw new Exception("Question content is required and must be at least 10 characters.");
+                        if (q.Points < 1 || q.Points > 100)
+                            throw new Exception("Points must be between 1 and 100.");
+                        if (q.Choices == null || q.Choices.Count < 2)
+                            throw new Exception("At least 2 choices are required.");
+                        if (!q.Choices.Any(c => c.IsCorrect))
+                            throw new Exception("At least one correct choice is required.");
+
+                        // Check for duplicate question
+                        var isExisted = await _questionRepository.AnyAsync(x => x.questionText == q.Content);
+                        if (isExisted)
+                            throw new Exception("A question with the same text already exists.");
+
+                        // Find SubContent
+                        var subContent = await _subContentRepository.GetFirstOrDefaultAsync(
+                            s => s.ContentName == q.ContentName
+                              && s.Level == q.Level
+                              && s.SubContentName == q.SubContentName
+                        );
+                        if (subContent == null)
+                            throw new Exception("SubContent does not exist for the provided ContentName, Level, and SubContentName.");
+
+                        // Create Question
+                        var question = new Question
+                        {
+                            questionId = Guid.NewGuid(),
+                            questionText = q.Content,
+                            explanation = q.Explanation ?? string.Empty,
+                            questionType = "multiple-choice",
+                            points = q.Points,
+                            difficulty = q.Difficulty,
+                            SubContentId = subContent.SubContentId,
+                            isActive = q.IsActive
+                        };
+                        await _questionRepository.InsertAsync(question);
+
+                        // Create Choices
+                        foreach (var c in q.Choices)
+                        {
+                            var choice = new Choice
+                            {
+                                choiceId = Guid.NewGuid(),
+                                questionId = question.questionId,
+                                choiceText = c.Content,
+                                isCorrect = c.IsCorrect
+                            };
+                            await _choiceRepository.InsertAsync(choice);
+                        }
+
+                        await _questionRepository.SaveChangesAsync();
+                        success++;
+                    }
+                    catch (Exception ex)
+                    {
+                        failed++;
+                        failedList.Add(new ImportQuestionErrorDto
+                        {
+                            QuestionText = q.Content,
+                            Error = ex.Message
+                        });
+                    }
+                }
+
+                // Write failedList to a file and return its path
+                if (failedList.Count > 0)
+                {
+                    var failedJson = JsonSerializer.Serialize(failedList, new JsonSerializerOptions { WriteIndented = true });
+                    var fileName = $"import_failed_{DateTime.UtcNow:yyyyMMddHHmmss}.json";
+                    var filePath = Path.Combine(Path.GetTempPath(), fileName);
+                    await File.WriteAllTextAsync(filePath, failedJson);
+                    result.FailedFileUrl = fileName;
+                }
+
+                result.TotalCount = total;
+                result.SuccessCount = success;
+                result.FailedCount = failed;
+                result.FailedQuestions = failedList;
+                return result;
+            }
+            catch (ApiException) { throw; }
+            catch (Exception ex)
+            {
+                throw ApiException.InternalServerError("IMPORT_QUESTIONS_ERROR", $"Error importing questions: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
This pull request introduces a new feature for batch importing questions via a JSON file upload, with detailed error handling and reporting. It adds new DTOs to support the import process, implements the core import logic in the service layer, and exposes a new API endpoint. An example JSON file is also provided to guide users on the expected format.

**New Question Import Feature**

* Added a new API endpoint `POST /api/questions/import` in `QuestionController` to handle multipart/form-data uploads for importing questions, returning either a summary or a downloadable JSON of failed imports.
* Implemented the `ImportQuestionsAsync` method in `QuestionService` to process the uploaded file, validate and insert questions and choices, skip unsupported types, and generate a report of failed imports.
* Updated the `IQuestionService` interface to include the new `ImportQuestionsAsync` method.
* Injected `IChoiceRepository` into `QuestionService` to support choice creation during import.

**Supporting Data Structures and Documentation**

* Added DTOs: `ImportQuestionsRequestDto` for file uploads, `ImportQuestionJsonDto`/`ImportChoiceJsonDto` for question structure, and `ImportQuestionsResultDto`/`ImportQuestionErrorDto` for result reporting. [[1]](diffhunk://#diff-b12e5994c3c4228dd2d8f7721e70130ab08fa2e8168a306780ef1beb55db9f6aR1-R10) [[2]](diffhunk://#diff-c34c9f26b77d8c6623a28bffe1490aadee4a58f9bd9fb98a672e4025728505aaR1-R24) [[3]](diffhunk://#diff-19eb0a975886b85fe5f6a70af449aa38d3ed3f44647bcede86b990f4660b7eb5R1-R19)
* Provided an `example.json` file illustrating the expected format for batch question imports, including both valid and intentionally failing entries.-add function import json for question