### PR TITLE
fix: lesson count

### DIFF
--- a/JCertPreApplication.Application/Contracts/ILessonRepository.cs
+++ b/JCertPreApplication.Application/Contracts/ILessonRepository.cs
@@ -1,6 +1,7 @@
 using JCertPreApplication.Application.Dtos.Lesson;
 using JCertPreApplication.Application.Utilities;
 using JCertPreApplication.Domain.Entities;
+using System.Linq.Expressions;
 
 namespace JCertPreApplication.Application.Contracts
 {
@@ -15,5 +16,6 @@ namespace JCertPreApplication.Application.Contracts
         int pageSize);
         Task<Test?> GetTestByLessonIdAsync(Guid lessonId);
         Task<bool> IsUserPassedTestAsync(Guid userId, Guid testId);
+        Task<int> CountAsync(Expression<Func<Lesson, bool>> predicate);
     }
 }

--- a/JCertPreApplication.Application/Features/Lessons/LessonService.cs
+++ b/JCertPreApplication.Application/Features/Lessons/LessonService.cs
@@ -75,10 +75,7 @@ namespace JCertPreApplication.Application.Features.Lessons
                     int newOrder = updateLessonDto.LessonOrder.Value;
 
                     // Count lessons in course
-                    var totalLessons = await _lessonRepository.AnyAsync(l => l.courseId == lesson.courseId)
-                        ? await _lessonRepository.GetAllAsync(l => l.courseId == lesson.courseId)
-                            .ContinueWith(t => t.Result.Count)
-                        : 0;
+                    var totalLessons = await _lessonRepository.CountAsync(l => l.courseId == lesson.courseId);
 
                     if (newOrder < 1) newOrder = 1;
                     if (newOrder > totalLessons) newOrder = totalLessons;
@@ -134,10 +131,7 @@ namespace JCertPreApplication.Application.Features.Lessons
                     throw ApiException.NotFound("Course", courseId);
 
                 // Count lessons in course
-                var totalLessons = await _lessonRepository.AnyAsync(l => l.courseId == courseId)
-                    ? await _lessonRepository.GetAllAsync(l => l.courseId == courseId)
-                        .ContinueWith(t => t.Result.Count)
-                    : 0;
+                var totalLessons = await _lessonRepository.CountAsync(l => l.courseId == courseId);
 
                 int insertOrder = createLessonDto.LessonOrder;
                 if (insertOrder < 1) insertOrder = 1;

--- a/JCertPreApplication.Persistence/Repositories/LessonRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/LessonRepository.cs
@@ -1,5 +1,4 @@
 using JCertPreApplication.Application.Contracts;
-using JCertPreApplication.Application.Dtos.Lesson;
 using JCertPreApplication.Application.Utilities;
 using JCertPreApplication.Domain.Entities;
 using JCertPreApplication.Persistence.DatabaseContext;
@@ -58,6 +57,11 @@ namespace JCertPreApplication.Persistence.Repositories
         {
             return await _context.Set<TestAttempt>()
                 .AnyAsync(a => a.testId == testId && a.userId == userId && a.isPass == true);
+        }
+
+        public async Task<int> CountAsync(Expression<Func<Lesson, bool>> predicate)
+        {
+            return await _dbSet.CountAsync(predicate);
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new, more efficient method for counting lessons in a course by adding a `CountAsync` method to the `ILessonRepository` interface and its implementation. The existing logic for counting lessons in the `LessonService` is updated to use this new method, improving code readability and performance.

Repository interface and implementation updates:

* Added a `CountAsync` method to the `ILessonRepository` interface, allowing for efficient counting of lessons based on a predicate. [[1]](diffhunk://#diff-2b8fa3bf4a543030e88d05e56289a3744997ae0e022bbbec989920aecd8ed8a5R4) [[2]](diffhunk://#diff-2b8fa3bf4a543030e88d05e56289a3744997ae0e022bbbec989920aecd8ed8a5R19)
* Implemented the `CountAsync` method in `LessonRepository`, using Entity Framework's `CountAsync` for efficient database queries.

Service logic improvements:

* Updated the lesson count logic in both the `UpdateLessonAsync` and `CreateLessonAsync` methods in `LessonService` to use the new `CountAsync` method, replacing the previous approach that fetched all lessons and counted them in memory. [[1]](diffhunk://#diff-d0518b5432bead60769d57c0d671fee3a5da103f95cede538eaddb438bce662dL78-R78) [[2]](diffhunk://#diff-d0518b5432bead60769d57c0d671fee3a5da103f95cede538eaddb438bce662dL137-R134)