### PR TITLE
feat: test per day

### DIFF
--- a/JCertPreApplication.Application/Contracts/IEnrollmentRepository.cs
+++ b/JCertPreApplication.Application/Contracts/IEnrollmentRepository.cs
@@ -10,8 +10,9 @@ namespace JCertPreApplication.Application.Contracts
         Task<IEnumerable<Enrollment>> GetCourseEnrollmentsAsync(Guid courseId);
         Task<Enrollment?> GetEnrollmentWithDetailsAsync(Guid enrollmentId);
         Task<bool> IsUserEnrolledInCourseAsync(Guid userId, Guid courseId);
+        Task<bool> IsUserEnrolledInAnyCourseAsync(Guid userId);
         Task<long> GetTotalEnrollmentsCountAsync();
         Task<IEnumerable<MonthlyCount>> GetEnrollmentCountsByMonthAsync(DateTime startDate, DateTime endDate);
         Task<long> CountByDateRangeAsync(DateTime startDate, DateTime endDate);
     }
-} 
+}

--- a/JCertPreApplication.Application/Dtos/AttemptAnswer/CreateAttemptAnswerDto.cs
+++ b/JCertPreApplication.Application/Dtos/AttemptAnswer/CreateAttemptAnswerDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.AttemptAnswer

--- a/JCertPreApplication.Application/Dtos/AttemptAnswer/UpdateAttemptAnswerDto.cs
+++ b/JCertPreApplication.Application/Dtos/AttemptAnswer/UpdateAttemptAnswerDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.AttemptAnswer

--- a/JCertPreApplication.Application/Dtos/Feedback/CreateFeedbackDto.cs
+++ b/JCertPreApplication.Application/Dtos/Feedback/CreateFeedbackDto.cs
@@ -1,4 +1,5 @@
 
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.Feedback

--- a/JCertPreApplication.Application/Dtos/LessonProgress/CreateLessonProgressDto.cs
+++ b/JCertPreApplication.Application/Dtos/LessonProgress/CreateLessonProgressDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.LessonProgress

--- a/JCertPreApplication.Application/Dtos/StudyPlan/StudyPlanItemDto.cs
+++ b/JCertPreApplication.Application/Dtos/StudyPlan/StudyPlanItemDto.cs
@@ -9,7 +9,7 @@ namespace JCertPreApplication.Application.Dtos.StudyPlan
         public int Sequence { get; set; }
         public string ItemType { get; set; } = null!;
         public Guid? CourseId { get; set; }
-        public Guid? TestId { get; set; }
+        public Guid? TestTemplateTypeId { get; set; }
         public ItemStatus Status { get; set; }
     }
 }

--- a/JCertPreApplication.Application/Dtos/StudyPlan/UpdateStudyPlanItemDto.cs
+++ b/JCertPreApplication.Application/Dtos/StudyPlan/UpdateStudyPlanItemDto.cs
@@ -7,7 +7,7 @@ namespace JCertPreApplication.Application.Dtos.StudyPlan
         public int? Sequence { get; set; }
         public string? ItemType { get; set; }
         public Guid? CourseId { get; set; }
-        public Guid? TestId { get; set; }
+        public Guid? TestTemplateTypeId { get; set; }
         public ItemStatus? Status { get; set; }
     }
 } 

--- a/JCertPreApplication.Application/Dtos/Test/CreateAutoTestInput.cs
+++ b/JCertPreApplication.Application/Dtos/Test/CreateAutoTestInput.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using JCertPreApplication.Application.Dtos.Utilities;
 using JCertPreApplication.Domain.Enums;
 
 namespace JCertPreApplication.Application.Dtos.Test
@@ -6,6 +7,7 @@ namespace JCertPreApplication.Application.Dtos.Test
     public class CreateAutoTestInput
     {
         [Required(ErrorMessage = "TestType is required.")]
+        [AllowedTestType(ErrorMessage = "TestType must be either JLPTAuto or EntryAuto.")]
         public TestType TestType { get; set; }
 
         [Required(ErrorMessage = "CourseLevel is required.")]

--- a/JCertPreApplication.Application/Dtos/TestAttempt/StartTestAttemptDto.cs
+++ b/JCertPreApplication.Application/Dtos/TestAttempt/StartTestAttemptDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.TestAttempt;

--- a/JCertPreApplication.Application/Dtos/TestAttempt/SubmitTestAttemptDto.cs
+++ b/JCertPreApplication.Application/Dtos/TestAttempt/SubmitTestAttemptDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 namespace JCertPreApplication.Application.Dtos.TestAttempt;
 public class SubmitTestAttemptDto

--- a/JCertPreApplication.Application/Dtos/TestQuestion/AddTestQuestionManualDto.cs
+++ b/JCertPreApplication.Application/Dtos/TestQuestion/AddTestQuestionManualDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.TestQuestion;

--- a/JCertPreApplication.Application/Dtos/TestTemplate/CreateTestTemplateDto.cs
+++ b/JCertPreApplication.Application/Dtos/TestTemplate/CreateTestTemplateDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 namespace JCertPreApplication.Application.Dtos.TestTemplate;
 public class CreateTestTemplateDto

--- a/JCertPreApplication.Application/Dtos/TestTemplateConfig/CreateTestTemplateConfigDto.cs
+++ b/JCertPreApplication.Application/Dtos/TestTemplateConfig/CreateTestTemplateConfigDto.cs
@@ -1,3 +1,4 @@
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel.DataAnnotations;
 
 namespace JCertPreApplication.Application.Dtos.TestTemplateConfig

--- a/JCertPreApplication.Application/Dtos/TestTemplateType/CreateTestTemplateTypeDto.cs
+++ b/JCertPreApplication.Application/Dtos/TestTemplateType/CreateTestTemplateTypeDto.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using JCertPreApplication.Application.Dtos.Utilities;
 using JCertPreApplication.Domain.Enums;
-using JCertPreApplication.Application.Dtos;
 namespace JCertPreApplication.Application.Dtos.TestTemplateType;
 public class CreateTestTemplateTypeDto
 {

--- a/JCertPreApplication.Application/Dtos/Utilities/AllowedTestTypeAttribute.cs
+++ b/JCertPreApplication.Application/Dtos/Utilities/AllowedTestTypeAttribute.cs
@@ -1,0 +1,22 @@
+﻿using JCertPreApplication.Domain.Enums;
+using System.ComponentModel.DataAnnotations;
+
+namespace JCertPreApplication.Application.Dtos.Utilities
+{
+    public class AllowedTestTypeAttribute : ValidationAttribute
+    {
+        public override bool IsValid(object? value)
+        {
+            if (value is TestType testType)
+            {
+                return testType == TestType.JLPTAuto || testType == TestType.EntryAuto;
+            }
+            return false;
+        }
+
+        public override string FormatErrorMessage(string name)
+        {
+            return $"{name} must be either JLPTAuto or EntryAuto.";
+        }
+    }
+}

--- a/JCertPreApplication.Application/Dtos/Utilities/EnumValueDto.cs
+++ b/JCertPreApplication.Application/Dtos/Utilities/EnumValueDto.cs
@@ -1,4 +1,4 @@
-namespace JCertPreApplication.Application.Dtos;
+namespace JCertPreApplication.Application.Dtos.Utilities;
 public class EnumValueDto
 {
     public string Name { get; set; } = default!;

--- a/JCertPreApplication.Application/Dtos/Utilities/NotDefaultGuidAttribute.cs
+++ b/JCertPreApplication.Application/Dtos/Utilities/NotDefaultGuidAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 
-namespace JCertPreApplication.Application.Dtos
+namespace JCertPreApplication.Application.Dtos.Utilities
 {
     // Custom validation attribute for non-default GUIDs
     public class NotDefaultGuidAttribute : ValidationAttribute

--- a/JCertPreApplication.Application/Features/StudyPlanItem/StudyPlanItemService.cs
+++ b/JCertPreApplication.Application/Features/StudyPlanItem/StudyPlanItemService.cs
@@ -29,7 +29,7 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
                 sequence = sequence,
                 itemType = itemType,
                 courseId = courseId,
-                testId = testId,
+                TestTemplateTypeId = testId,
                 status = status
             };
             await _studyPlanItemRepository.CreateStudyPlanItemAsync(studyPlanItem);
@@ -67,8 +67,8 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
                 existingItem.itemType = updateDto.ItemType;
             if (updateDto.CourseId.HasValue)
                 existingItem.courseId = updateDto.CourseId;
-            if (updateDto.TestId.HasValue)
-                existingItem.testId = updateDto.TestId;
+            if (updateDto.TestTemplateTypeId.HasValue)
+                existingItem.TestTemplateTypeId = updateDto.TestTemplateTypeId;
             if (updateDto.Status.HasValue)
                 existingItem.status = updateDto.Status.Value;
 
@@ -94,7 +94,7 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
                 Sequence = studyPlanItem.sequence,
                 ItemType = studyPlanItem.itemType,
                 CourseId = studyPlanItem.courseId,
-                TestId = studyPlanItem.testId,
+                TestTemplateTypeId = studyPlanItem.TestTemplateTypeId,
                 Status = studyPlanItem.status
             };
         }

--- a/JCertPreApplication.Application/Features/SubContents/ISubContentService.cs
+++ b/JCertPreApplication.Application/Features/SubContents/ISubContentService.cs
@@ -1,5 +1,5 @@
-using JCertPreApplication.Application.Dtos;
 using JCertPreApplication.Application.Dtos.SubContent;
+using JCertPreApplication.Application.Dtos.Utilities;
 using JCertPreApplication.Application.Utilities;
 using JCertPreApplication.Domain.Entities;
 using JCertPreApplication.Domain.Enums;

--- a/JCertPreApplication.Application/Features/SubContents/SubContentService.cs
+++ b/JCertPreApplication.Application/Features/SubContents/SubContentService.cs
@@ -1,6 +1,6 @@
 using JCertPreApplication.Application.Contracts;
-using JCertPreApplication.Application.Dtos;
 using JCertPreApplication.Application.Dtos.SubContent;
+using JCertPreApplication.Application.Dtos.Utilities;
 using JCertPreApplication.Application.Exceptions;
 using JCertPreApplication.Application.Utilities;
 using JCertPreApplication.Domain.Entities;

--- a/JCertPreApplication.Application/Features/TestAttempts/TestAttemptService.cs
+++ b/JCertPreApplication.Application/Features/TestAttempts/TestAttemptService.cs
@@ -262,10 +262,6 @@ public class TestAttemptService : ITestAttemptService
                     }
                 }
             }
-            else if (test.testType == TestType.CustomAuto)
-            {
-                isPass = null;
-            }
 
             attempt.isPass = isPass;
             await _testAttemptRepository.UpdateAsync(attempt);
@@ -344,14 +340,17 @@ public class TestAttemptService : ITestAttemptService
         }
     }
 
-    // Helper: Map entity to DTO
+    // Fix for CS0266 and CS8629 in MapToDto: safely handle nullable Guid (testId)
     private static TestAttemptDto MapToDto(TestAttempt attempt)
     {
+        if (attempt.testId == null)
+            throw new InvalidOperationException("TestAttempt.testId is null when mapping to TestAttemptDto.");
+
         return new TestAttemptDto
         {
             AttemptId = attempt.attemptId,
             UserId = attempt.userId,
-            TestId = attempt.testId,
+            TestId = attempt.testId.Value,
             AttemptNumber = attempt.attemptNumber,
             Status = attempt.status,
             StartTime = attempt.startTime,

--- a/JCertPreApplication.Application/Features/TestAttempts/TestAttemptService.cs
+++ b/JCertPreApplication.Application/Features/TestAttempts/TestAttemptService.cs
@@ -344,7 +344,7 @@ public class TestAttemptService : ITestAttemptService
     private static TestAttemptDto MapToDto(TestAttempt attempt)
     {
         if (attempt.testId == null)
-            throw new InvalidOperationException("TestAttempt.testId is null when mapping to TestAttemptDto.");
+            throw ApiException.InternalServerError("NULL_TEST_ID", "TestAttempt.testId is null when mapping to TestAttemptDto.");
 
         return new TestAttemptDto
         {

--- a/JCertPreApplication.Application/Features/Tests/TestService.cs
+++ b/JCertPreApplication.Application/Features/Tests/TestService.cs
@@ -18,6 +18,8 @@ namespace JCertPreApplication.Application.Features.Tests
         private readonly ITestAttemptRepository _testAttemptRepository;
         private readonly ITestTemplateTypeRepository _testTemplateTypeRepository;
         private readonly ITestQuestionService _testQuestionService;
+        private readonly IEnrollmentRepository _enrollmentRepository;
+        private readonly IStudentProfileRepository _studentProfileRepository;
 
         public TestService(
             ITestRepository testRepository,
@@ -26,7 +28,9 @@ namespace JCertPreApplication.Application.Features.Tests
             ITestQuestionRepository testQuestionRepository,
             ITestAttemptRepository testAttemptRepository,
             ITestTemplateTypeRepository testTemplateTypeRepository,
-            ITestQuestionService testQuestionService)
+            ITestQuestionService testQuestionService,
+            IEnrollmentRepository enrollmentRepository,
+            IStudentProfileRepository studentProfileRepository)
         {
             _testRepository = testRepository ?? throw new ArgumentNullException(nameof(testRepository));
             _lessonRepository = lessonRepository ?? throw new ArgumentNullException(nameof(lessonRepository));
@@ -35,6 +39,8 @@ namespace JCertPreApplication.Application.Features.Tests
             _testAttemptRepository = testAttemptRepository ?? throw new ArgumentNullException(nameof(testAttemptRepository));
             _testTemplateTypeRepository = testTemplateTypeRepository ?? throw new ArgumentNullException(nameof(testTemplateTypeRepository));
             _testQuestionService = testQuestionService ?? throw new ArgumentNullException(nameof(testQuestionService));
+            _enrollmentRepository = enrollmentRepository ?? throw new ArgumentNullException(nameof(enrollmentRepository));
+            _studentProfileRepository = studentProfileRepository ?? throw new ArgumentNullException(nameof(studentProfileRepository));
         }
 
         /// <summary>
@@ -133,65 +139,28 @@ namespace JCertPreApplication.Application.Features.Tests
                 if (existingTest != null)
                     throw ApiException.BadRequest("TEST_ALREADY_EXISTS", "A test already exists for this lesson. Each lesson can only have one test.");
 
-                int durationMinutes = 0;
-                Guid? testTemplateTypeId = null;
-                List<TestTemplate>? templates = null;
-
-                switch (dto.TestType)
-                {
-                    case TestType.JLPTAuto:
-                        var jlptType = await FindActiveTemplateType(dto.CourseLevel, TestType.JLPTAuto);
-                        testTemplateTypeId = jlptType.TestTemplateTypeId;
-                        templates = await _testTemplateRepository.GetAllAsync(t => t.TestTemplateTypeId == testTemplateTypeId);
-                        if (templates == null || templates.Count == 0)
-                            throw ApiException.BadRequest("NO_TEMPLATES_FOUND", "No active test templates found for the provided TestTemplateTypeId.");
-                        durationMinutes = templates.Sum(t => t.durationMinutes);
-                        break;
-
-                    case TestType.CustomManual:
-                        durationMinutes = dto.DurationMinutes;
-                        break;
-
-                    case TestType.CustomAuto:
-                        var customAutoType = await FindActiveTemplateType(dto.CourseLevel, TestType.JLPTAuto);
-                        testTemplateTypeId = customAutoType.TestTemplateTypeId;
-                        durationMinutes = 0;
-                        break;
-
-                    case TestType.EntryAuto:
-                        break;
-                }
-
-                decimal passingPercentage = (dto.TestType == TestType.JLPTAuto ||
-                                             dto.TestType == TestType.EntryAuto ||
-                                             dto.TestType == TestType.CustomAuto)
-                    ? 0m
-                    : dto.PassingPercentage;
-
                 var test = new Test
                 {
                     testId = Guid.NewGuid(),
                     title = dto.Title,
                     description = dto.Description,
-                    testType = dto.TestType,
+                    testType = TestType.CustomManual,
                     courseLevel = dto.CourseLevel,
-                    durationMinutes = durationMinutes,
+                    durationMinutes = dto.DurationMinutes,
                     lessonId = lessonId,
                     createdByUserId = userId,
                     availableFrom = dto.AvailableFrom,
                     availableTo = dto.AvailableTo,
                     maxAttempts = dto.MaxAttempts,
-                    passing_percentage = passingPercentage,
+                    passing_percentage = dto.PassingPercentage,
                     status = TestStatus.Close,
-                    TestTemplateTypeId = testTemplateTypeId
+                    TestTemplateTypeId = null
                 };
 
                 await _testRepository.InsertAsync(test);
                 await _testRepository.SaveChangesAsync();
 
                 var createdTest = await _testRepository.GetByIdAsync(test.testId);
-                if (createdTest != null && createdTest.TestTemplateTypeId.HasValue && templates != null)
-                    createdTest.TestTemplateType = templates.FirstOrDefault()?.TestTemplateType;
 
                 return MapToTestDto(createdTest ?? test);
             }
@@ -212,60 +181,22 @@ namespace JCertPreApplication.Application.Features.Tests
                 var test = await _testRepository.GetByIdAsync(testId)
                     ?? throw ApiException.NotFound("Test", testId);
 
-                var hasQuestions = await _testQuestionRepository.AnyAsync(q => q.testId == testId);
-
-                if (dto.TestType.HasValue)
-                {
-                    if (hasQuestions)
-                        throw ApiException.BadRequest("UPDATE_TEST_TYPE_NOT_ALLOWED", "Cannot update test type if there are questions.");
-                    test.testType = dto.TestType.Value;
-                }
-
                 if (!string.IsNullOrWhiteSpace(dto.Title))
                     test.title = dto.Title;
                 if (!string.IsNullOrWhiteSpace(dto.Description))
                     test.description = dto.Description;
                 if (dto.DurationMinutes.HasValue)
-                {
-                    if (test.testType != TestType.CustomManual)
-                        throw ApiException.BadRequest("UPDATE_DURATION_NOT_ALLOWED", "Can only update duration minutes for CustomManual test type.");
                     test.durationMinutes = dto.DurationMinutes.Value;
-                }
                 if (dto.AvailableFrom.HasValue)
                     test.availableFrom = dto.AvailableFrom.Value;
                 if (dto.AvailableTo.HasValue)
                     test.availableTo = dto.AvailableTo.Value;
                 if (dto.MaxAttempts.HasValue)
                     test.maxAttempts = dto.MaxAttempts.Value;
-
-                var newType = dto.TestType ?? test.testType;
-
                 if (dto.CourseLevel.HasValue)
-                {
-                    if (newType == TestType.CustomManual)
-                    {
-                        test.courseLevel = dto.CourseLevel.Value;
-                    }
-                    else if (newType == TestType.JLPTAuto || newType == TestType.CustomAuto)
-                    {
-                        if (hasQuestions)
-                            throw ApiException.BadRequest("UPDATE_COURSE_LEVEL_NOT_ALLOWED", "Cannot update course level if there are questions for JLPTAuto or CustomAuto test type.");
-
-                        test.courseLevel = dto.CourseLevel.Value;
-
-                        var jlptType = await FindActiveTemplateType(dto.CourseLevel.Value, TestType.JLPTAuto);
-                        test.TestTemplateTypeId = jlptType.TestTemplateTypeId;
-                        var templates = await _testTemplateRepository.GetAllAsync(t => t.TestTemplateTypeId == test.TestTemplateTypeId);
-                        if (templates == null || templates.Count == 0)
-                            throw ApiException.BadRequest("NO_TEMPLATES_FOUND", "No active test templates found for the provided TestTemplateTypeId.");
-                        test.durationMinutes = templates.Sum(t => t.durationMinutes);
-                    }
-                }
-
+                   test.courseLevel = dto.CourseLevel.Value;
                 if (dto.PassingPercentage.HasValue)
                 {
-                    if (newType == TestType.JLPTAuto || newType == TestType.EntryAuto || newType == TestType.CustomAuto)
-                        throw ApiException.BadRequest("UPDATE_PASSING_PERCENTAGE_NOT_ALLOWED", "Cannot update PassingPercentage for JLPTAuto, EntryAuto, or CustomAuto test types.");
                     if (test.status != TestStatus.Close)
                         throw ApiException.BadRequest("UPDATE_PASSING_PERCENTAGE_NOT_ALLOWED", "Can only update PassingPercentage if the test is closed.");
                     test.passing_percentage = dto.PassingPercentage.Value;
@@ -273,7 +204,7 @@ namespace JCertPreApplication.Application.Features.Tests
                 await _testRepository.UpdateAsync(test);
                 await _testRepository.SaveChangesAsync();
 
-                var updatedTest = await _testRepository.GetFirstOrDefaultAsync(t => t.testId == testId, "TestTemplateType");
+                var updatedTest = await _testRepository.GetFirstOrDefaultAsync(t => t.testId == testId);
                 return MapToTestDto(updatedTest ?? test);
             }
             catch (ApiException) { throw; }
@@ -387,31 +318,32 @@ namespace JCertPreApplication.Application.Features.Tests
             }
         }
 
-        // Helper method for finding active TestTemplateType
-        private async Task<TestTemplateType> FindActiveTemplateType(CourseLevel courseLevel, TestType testType)
-        {
-            try
-            {
-                var type = await _testTemplateTypeRepository.GetFirstOrDefaultAsync(
-                    t => t.courseLevel == courseLevel
-                        && t.isActive
-                        && t.testType == testType
-                );
-                if (type == null)
-                    throw ApiException.BadRequest("NO_TEMPLATE_TYPE_FOUND", $"No active test template type found for the provided course level and {testType} type.");
-                return type;
-            }
-            catch (ApiException) { throw; }
-            catch (Exception ex)
-            {
-                throw ApiException.InternalServerError("TEST_SERVICE_ERROR", $"An error occurred while finding active template type: {ex.Message}");
-            }
-        }
-
         public async Task<CreateAutoTestResult> CreateAutoTestAndAddQuestionsAsync(CreateAutoTestInput input, Guid userId)
         {
             try
             {
+                // 1. Check enrollment
+                if (!await _enrollmentRepository.IsUserEnrolledInAnyCourseAsync(userId))
+                    throw ApiException.BadRequest("USER_NOT_ENROLLED", "User must be enrolled in at least one course to take an auto test.");
+
+                // 2. Check student profile and last reset test time
+                var studentProfile = await _studentProfileRepository.GetFirstOrDefaultAsync(sp => sp.userId == userId);
+                if (studentProfile == null)
+                    throw ApiException.BadRequest("NO_STUDENT_PROFILE", "Student profile not found.");
+
+                var now = DateTime.UtcNow;
+                if (studentProfile.lastResetTestTime != null && studentProfile.lastResetTestTime.Value.Date == now.Date)
+                {
+                    throw ApiException.BadRequest("TEST_NOT_AVAILABLE", "You can only take the test once per day.");
+                }
+
+                // 3. Update lastResetTestTime and increment numberOfTestsTaken
+                studentProfile.lastResetTestTime = now;
+                studentProfile.numberOfTestsTaken += 1;
+                await _studentProfileRepository.UpdateAsync(studentProfile);
+                await _studentProfileRepository.SaveChangesAsync();
+
+                // 4. Continue with the original logic
                 var templateType = await _testTemplateTypeRepository.GetFirstOrDefaultAsync(
                     t => t.courseLevel == input.CourseLevel
                         && t.isActive
@@ -426,7 +358,6 @@ namespace JCertPreApplication.Application.Features.Tests
 
                 int durationMinutes = templates.Sum(t => t.durationMinutes);
 
-                var now = DateTime.UtcNow;
                 var test = new Test
                 {
                     testId = Guid.NewGuid(),

--- a/JCertPreApplication.Application/Features/Tests/TestService.cs
+++ b/JCertPreApplication.Application/Features/Tests/TestService.cs
@@ -326,22 +326,28 @@ namespace JCertPreApplication.Application.Features.Tests
                 if (!await _enrollmentRepository.IsUserEnrolledInAnyCourseAsync(userId))
                     throw ApiException.BadRequest("USER_NOT_ENROLLED", "User must be enrolled in at least one course to take an auto test.");
 
-                // 2. Check student profile and last reset test time
+                // 2. Check student profile and per-day test limit
                 var studentProfile = await _studentProfileRepository.GetFirstOrDefaultAsync(sp => sp.userId == userId);
                 if (studentProfile == null)
                     throw ApiException.BadRequest("NO_STUDENT_PROFILE", "Student profile not found.");
 
                 var now = DateTime.UtcNow;
-                if (studentProfile.lastResetTestTime != null && studentProfile.lastResetTestTime.Value.Date == now.Date)
+
+                // If lastResetTestTime is not today, reset the counter
+                if (studentProfile.lastResetTestTime == null || studentProfile.lastResetTestTime.Value.Date < now.Date)
                 {
-                    throw ApiException.BadRequest("TEST_NOT_AVAILABLE", "You can only take the test once per day.");
+                    studentProfile.numberOfTestsTaken = 0;
                 }
 
-                // 3. Update lastResetTestTime and increment numberOfTestsTaken
-                studentProfile.lastResetTestTime = now;
+                if (studentProfile.numberOfTestsTaken >= 10)
+                    throw ApiException.BadRequest("TEST_LIMIT_REACHED", "You can only take the auto test 10 times per day.");
+
+                // Increment the counter and update the last reset time
                 studentProfile.numberOfTestsTaken += 1;
+                studentProfile.lastResetTestTime = now;
                 await _studentProfileRepository.UpdateAsync(studentProfile);
                 await _studentProfileRepository.SaveChangesAsync();
+
 
                 // 4. Continue with the original logic
                 var templateType = await _testTemplateTypeRepository.GetFirstOrDefaultAsync(

--- a/JCertPreApplication.Application/Utilities/EnumHelper.cs
+++ b/JCertPreApplication.Application/Utilities/EnumHelper.cs
@@ -1,4 +1,4 @@
-using JCertPreApplication.Application.Dtos;
+using JCertPreApplication.Application.Dtos.Utilities;
 using System.ComponentModel;
 namespace JCertPreApplication.Application.Utilities;
 public static class EnumHelper

--- a/JCertPreApplication.Domain/Entities/Lesson.cs
+++ b/JCertPreApplication.Domain/Entities/Lesson.cs
@@ -7,12 +7,12 @@ namespace JCertPreApplication.Domain.Entities
         public string title { get; set; } = null!;
         public int lessonOrder { get; set; }
         public string content { get; set; } = null!;
-        public string? comment { get; set; } // Nullable comment field
+        public string? comment { get; set; }
 
         // Navigation properties
         public virtual Course Course { get; set; } = null!;
         public virtual ICollection<Document> Documents { get; set; } = new List<Document>();
-        public virtual ICollection<Test> Tests { get; set; } = new List<Test>();
+        public virtual Test? Test { get; set; } // 1-1 with Test
         public virtual ICollection<LessonProgress> LessonProgresses { get; set; } = new List<LessonProgress>();
     }
 }

--- a/JCertPreApplication.Domain/Entities/StudentProfile.cs
+++ b/JCertPreApplication.Domain/Entities/StudentProfile.cs
@@ -5,6 +5,8 @@
         public Guid userId { get; set; }
         public string currentLevel { get; set; } = null!;
         public string learningGoals { get; set; } = null!;
+        public int numberOfTestsTaken { get; set; } = 0;
+        public DateTime? lastResetTestTime { get; set; } 
 
         // Navigation property
         public virtual User User { get; set; } = null!;

--- a/JCertPreApplication.Domain/Entities/StudyPlanItem.cs
+++ b/JCertPreApplication.Domain/Entities/StudyPlanItem.cs
@@ -6,15 +6,16 @@ namespace JCertPreApplication.Domain.Entities
     {
         public Guid itemId { get; set; }
         public Guid planId { get; set; }
-        public int sequence { get; set; } //thu tu thuc hien trong ke hoach hoc tap
+        public int sequence { get; set; }
         public string itemType { get; set; } = null!;
         public Guid? courseId { get; set; }
-        public Guid? testId { get; set; }
+        public Guid? TestTemplateTypeId { get; set; }
+        public string? description { get; set; }
         public ItemStatus status { get; set; }
 
         // Navigation property
         public virtual StudyPlan StudyPlan { get; set; } = null!;
-        public virtual Course Course { get; set; } = null!;
-        public virtual Test Test { get; set; } = null!;
+        public virtual Course? Course { get; set; }
+        public virtual TestTemplateType? TestTemplateType { get; set; }
     }
 }

--- a/JCertPreApplication.Domain/Entities/Test.cs
+++ b/JCertPreApplication.Domain/Entities/Test.cs
@@ -24,7 +24,6 @@ namespace JCertPreApplication.Domain.Entities
         public virtual TestTemplateType? TestTemplateType { get; set; } = null!;
         public virtual ICollection<TestQuestion> TestQuestions { get; set; } = new List<TestQuestion>();
         public virtual ICollection<TestAttempt> TestAttempts { get; set; } = new List<TestAttempt>();
-        public virtual ICollection<StudyPlanItem> StudyPlanItems { get; set; } = new List<StudyPlanItem>();
         public virtual ICollection<TestScoreSummary> TestScoreSummaries { get; set; } = new List<TestScoreSummary>();
     }
 }

--- a/JCertPreApplication.Domain/Entities/TestAttempt.cs
+++ b/JCertPreApplication.Domain/Entities/TestAttempt.cs
@@ -7,7 +7,7 @@ namespace JCertPreApplication.Domain.Entities
     {
         public Guid attemptId { get; set; }
         public Guid userId { get; set; }
-        public Guid testId { get; set; }
+        public Guid? testId { get; set; }
         public DateTime startTime { get; set; }
         public DateTime endTime { get; set; }
         public int attemptNumber { get; set; }

--- a/JCertPreApplication.Domain/Entities/TestTemplateType.cs
+++ b/JCertPreApplication.Domain/Entities/TestTemplateType.cs
@@ -21,5 +21,6 @@ namespace JCertPreApplication.Domain.Entities
         public virtual User? VerifiedByUser { get; set; } // NEW NAVIGATION
         public virtual ICollection<TestTemplate> TestTemplates { get; set; } = new List<TestTemplate>();
         public virtual ICollection<Test> Tests { get; set; } = new List<Test>();
+        public virtual ICollection<StudyPlanItem> StudyPlanItems { get; set; } = new List<StudyPlanItem>();
     }
 }

--- a/JCertPreApplication.Domain/Enums/TestType.cs
+++ b/JCertPreApplication.Domain/Enums/TestType.cs
@@ -3,6 +3,5 @@ public enum TestType
 {
     JLPTAuto,
     EntryAuto,
-    CustomManual,
-    CustomAuto
+    CustomManual
 }

--- a/JCertPreApplication.Persistence/Configurations/ChoiceConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/ChoiceConfiguration.cs
@@ -26,7 +26,7 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.HasOne(c => c.Question)
                    .WithMany(q => q.Choices)
                    .HasForeignKey(c => c.questionId)
-                   .OnDelete(DeleteBehavior.NoAction);
+                   .OnDelete(DeleteBehavior.Cascade);
 
             builder.HasMany(c => c.AttemptAnswers)
                    .WithOne(aa => aa.Choice)

--- a/JCertPreApplication.Persistence/Configurations/DocumentConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/DocumentConfiguration.cs
@@ -21,7 +21,7 @@ namespace JCertPreApplication.Persistence.Configurations
             // Configure foreign key relationship
             builder.HasOne(d => d.Lesson)
                    .WithMany(l => l.Documents)
-                   .HasForeignKey(d => d.lessonId).OnDelete(DeleteBehavior.NoAction);
+                   .HasForeignKey(d => d.lessonId).OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/LessonConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/LessonConfiguration.cs
@@ -22,15 +22,15 @@ namespace JCertPreApplication.Persistence.Configurations
                 .HasForeignKey(l => l.courseId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            builder.HasOne(l => l.Test)
+                .WithOne(t => t.Lesson)
+                .HasForeignKey<Test>(t => t.lessonId)
+                .OnDelete(DeleteBehavior.Cascade);
+
             builder.HasMany(l => l.Documents)
                 .WithOne(d => d.Lesson)
                 .HasForeignKey(d => d.lessonId)
                 .OnDelete(DeleteBehavior.Cascade);
-
-            builder.HasMany(l => l.Tests)
-                .WithOne(t => t.Lesson)
-                .HasForeignKey(t => t.lessonId)
-                .OnDelete(DeleteBehavior.NoAction);
 
             builder.HasMany(l => l.LessonProgresses)
                 .WithOne(lp => lp.Lesson)

--- a/JCertPreApplication.Persistence/Configurations/QuestionAttachmentConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/QuestionAttachmentConfiguration.cs
@@ -20,7 +20,7 @@ namespace JCertPreApplication.Persistence.Configurations
             // Configure foreign key relationship
             builder.HasOne(qa => qa.Question)
                    .WithMany(q => q.QuestionAttachments)
-                   .HasForeignKey(qa => qa.questionId).OnDelete(DeleteBehavior.NoAction);
+                   .HasForeignKey(qa => qa.questionId).OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/QuestionConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/QuestionConfiguration.cs
@@ -39,15 +39,16 @@ namespace JCertPreApplication.Persistence.Configurations
 
         builder.HasOne(q => q.SubContent)
             .WithMany(sc => sc.Questions)
-            .HasForeignKey(q => q.SubContentId)
+            .HasForeignKey(q => q.SubContentId).OnDelete(DeleteBehavior.NoAction)
             .IsRequired();
 
         // Add new one-to-many for TestQuestion
         builder.HasMany(q => q.TestQuestions)
             .WithOne(tq => tq.Question)
-            .HasForeignKey(tq => tq.questionId);
+            .HasForeignKey(tq => tq.questionId)
+            .OnDelete(DeleteBehavior.NoAction);
 
-        builder.HasMany(q => q.Choices)
+            builder.HasMany(q => q.Choices)
             .WithOne(c => c.Question)
             .HasForeignKey(c => c.questionId)
             .OnDelete(DeleteBehavior.Cascade);
@@ -60,7 +61,7 @@ namespace JCertPreApplication.Persistence.Configurations
         builder.HasMany(q => q.AttemptAnswers)
             .WithOne(aa => aa.Question)
             .HasForeignKey(aa => aa.questionId)
-            .OnDelete(DeleteBehavior.SetNull);
+            .OnDelete(DeleteBehavior.NoAction);
 
 
         builder.HasIndex(q => q.SubContentId);

--- a/JCertPreApplication.Persistence/Configurations/StudentProfileConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/StudentProfileConfiguration.cs
@@ -8,18 +8,31 @@ namespace JCertPreApplication.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<StudentProfile> builder)
         {
-            // Configure primary key
+            // Table and primary key
             builder.ToTable("student_profile");
             builder.HasKey(sp => sp.userId);
 
-            // Configure required properties and constraints
-            builder.Property(sp => sp.currentLevel).IsRequired().HasMaxLength(50);
-            builder.Property(sp => sp.learningGoals).IsRequired();
+            // Required properties and constraints
+            builder.Property(sp => sp.currentLevel)
+                .IsRequired()
+                .HasMaxLength(50);
 
-            // Configure foreign key relationship
+            builder.Property(sp => sp.learningGoals)
+                .IsRequired();
+
+            // New properties
+            builder.Property(sp => sp.numberOfTestsTaken)
+                .IsRequired()
+                .HasDefaultValue(0);
+
+            builder.Property(sp => sp.lastResetTestTime)
+                .IsRequired(false);
+
+            // Foreign key relationship
             builder.HasOne(sp => sp.User)
-                   .WithOne()
-                   .HasForeignKey<StudentProfile>(sp => sp.userId).OnDelete(DeleteBehavior.NoAction);
+                   .WithOne(u => u.StudentProfile)
+                   .HasForeignKey<StudentProfile>(sp => sp.userId)
+                   .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/StudyPlanItemConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/StudyPlanItemConfiguration.cs
@@ -8,30 +8,33 @@ namespace JCertPreApplication.Persistence.Configurations
     {
         public void Configure(EntityTypeBuilder<StudyPlanItem> builder)
         {
-            // Configure primary key
             builder.ToTable("study_plan_item");
             builder.HasKey(spi => spi.itemId);
 
-            // Configure required properties and constraints
             builder.Property(spi => spi.planId).IsRequired();
             builder.Property(spi => spi.sequence).IsRequired();
             builder.Property(spi => spi.itemType).IsRequired().HasMaxLength(50);
-            builder.Property(spi => spi.courseId);
-            builder.Property(spi => spi.testId);
+            builder.Property(spi => spi.courseId).IsRequired(false);
+            builder.Property(spi => spi.TestTemplateTypeId).IsRequired(false);
+            builder.Property(spi => spi.description).HasMaxLength(1000).IsRequired(false);
             builder.Property(spi => spi.status).IsRequired().HasConversion<string>();
 
-            // Configure foreign key relationship
             builder.HasOne(spi => spi.StudyPlan)
                    .WithMany(sp => sp.StudyPlanItems)
-                   .HasForeignKey(spi => spi.planId).OnDelete(DeleteBehavior.NoAction);
+                   .HasForeignKey(spi => spi.planId)
+                   .OnDelete(DeleteBehavior.NoAction);
+
             builder.HasOne(spi => spi.Course)
                    .WithMany(sp => sp.StudyPlanItems)
-                   .IsRequired(false) // Nullable foreign key
-                   .HasForeignKey(spi => spi.courseId).OnDelete(DeleteBehavior.NoAction);
-            builder.HasOne(spi => spi.Test)
-                   .WithMany(sp => sp.StudyPlanItems)
-                   .IsRequired(false) // Nullable foreign key
-                   .HasForeignKey(spi => spi.testId).OnDelete(DeleteBehavior.NoAction);
+                   .HasForeignKey(spi => spi.courseId)
+                   .IsRequired(false)
+                   .OnDelete(DeleteBehavior.NoAction);
+
+            builder.HasOne(spi => spi.TestTemplateType)
+                   .WithMany()
+                   .HasForeignKey(spi => spi.TestTemplateTypeId)
+                   .IsRequired(false)
+                   .OnDelete(DeleteBehavior.SetNull);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/SubContentConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/SubContentConfiguration.cs
@@ -30,12 +30,12 @@ namespace JCertPreApplication.Persistence.Configurations
         builder.HasMany(sc => sc.Questions)
             .WithOne(q => q.SubContent)
             .HasForeignKey(q => q.SubContentId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.NoAction);
 
         builder.HasMany(sc => sc.TestTemplateConfigs)
             .WithOne(tc => tc.SubContent)
             .HasForeignKey(tc => tc.subContentId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.NoAction);
     }
 }
 }

--- a/JCertPreApplication.Persistence/Configurations/TestAttemptConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/TestAttemptConfiguration.cs
@@ -15,8 +15,8 @@ namespace JCertPreApplication.Persistence.Configurations
                 .IsRequired();
 
             builder.Property(ta => ta.testId)
-                .IsRequired();
-
+                .IsRequired(false);
+            
             builder.Property(ta => ta.startTime)
                 .IsRequired();
 

--- a/JCertPreApplication.Persistence/Configurations/TestConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/TestConfiguration.cs
@@ -57,9 +57,8 @@ namespace JCertPreApplication.Persistence.Configurations
                 .HasConversion<string>();
 
             builder.HasOne(t => t.Lesson)
-                .WithMany(l => l.Tests)
-                .HasForeignKey(t => t.lessonId)
-                .IsRequired(false)
+                .WithOne(l => l.Test)
+                .HasForeignKey<Test>(t => t.lessonId)
                 .OnDelete(DeleteBehavior.NoAction);
 
             builder.HasOne(t => t.CreatedByUser)
@@ -76,18 +75,13 @@ namespace JCertPreApplication.Persistence.Configurations
 
             builder.HasMany(t => t.TestQuestions)
                 .WithOne(tq => tq.Test)
-                .HasForeignKey(tq => tq.testId);
+                .HasForeignKey(tq => tq.testId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             builder.HasMany(t => t.TestAttempts)
                 .WithOne(ta => ta.Test)
                 .HasForeignKey(ta => ta.testId)
-                .OnDelete(DeleteBehavior.NoAction);
-
-            builder.HasMany(t => t.StudyPlanItems)
-                .WithOne(spi => spi.Test)
-                .HasForeignKey(spi => spi.testId)
-                .IsRequired(false)
-                .OnDelete(DeleteBehavior.NoAction);
+                .OnDelete(DeleteBehavior.SetNull);
 
             builder.HasMany(t => t.TestScoreSummaries)
                 .WithOne(tss => tss.Test)

--- a/JCertPreApplication.Persistence/Configurations/TestQuestionConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/TestQuestionConfiguration.cs
@@ -28,7 +28,7 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.HasOne(tq => tq.Question)
                 .WithMany(q => q.TestQuestions)
                 .HasForeignKey(tq => tq.questionId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/TestTemplateConfigConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/TestTemplateConfigConfiguration.cs
@@ -37,7 +37,7 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.HasOne(tc => tc.SubContent)
                 .WithMany(sc => sc.TestTemplateConfigs)
                 .HasForeignKey(tc => tc.subContentId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.NoAction);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Configurations/TestTemplateConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/TestTemplateConfiguration.cs
@@ -34,7 +34,7 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.HasOne(tt => tt.TestTemplateType)
                 .WithMany(ttt => ttt.TestTemplates)
                 .HasForeignKey(tt => tt.TestTemplateTypeId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .OnDelete(DeleteBehavior.Cascade);
 
             builder.HasMany(tt => tt.TestTemplateConfigs)
                 .WithOne(tc => tc.TestTemplate)

--- a/JCertPreApplication.Persistence/Configurations/TestTemplateTypeConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/TestTemplateTypeConfiguration.cs
@@ -64,6 +64,11 @@ namespace JCertPreApplication.Persistence.Configurations
                 .WithOne(test => test.TestTemplateType)
                 .HasForeignKey(test => test.TestTemplateTypeId)
                 .OnDelete(DeleteBehavior.SetNull);
+
+            builder.HasMany(t => t.StudyPlanItems)
+                .WithOne(spi => spi.TestTemplateType)
+                .HasForeignKey(spi => spi.TestTemplateTypeId)
+                .OnDelete(DeleteBehavior.SetNull);
         }
     }
 }

--- a/JCertPreApplication.Persistence/Migrations/20250822073528_TestTaken.Designer.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250822073528_TestTaken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JCertPreApplication.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JCertPreApplication.Persistence.Migrations
 {
     [DbContext(typeof(JCertPreDatabaseContext))]
-    partial class JCertPreDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250822073528_TestTaken")]
+    partial class TestTaken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -700,15 +703,8 @@ namespace JCertPreApplication.Persistence.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
-                    b.Property<Guid?>("TestTemplateTypeId")
-                        .HasColumnType("uuid");
-
                     b.Property<Guid?>("courseId")
                         .HasColumnType("uuid");
-
-                    b.Property<string>("description")
-                        .HasMaxLength(1000)
-                        .HasColumnType("character varying(1000)");
 
                     b.Property<string>("itemType")
                         .IsRequired()
@@ -725,13 +721,16 @@ namespace JCertPreApplication.Persistence.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.HasKey("itemId");
+                    b.Property<Guid?>("testId")
+                        .HasColumnType("uuid");
 
-                    b.HasIndex("TestTemplateTypeId");
+                    b.HasKey("itemId");
 
                     b.HasIndex("courseId");
 
                     b.HasIndex("planId");
+
+                    b.HasIndex("testId");
 
                     b.ToTable("study_plan_item", (string)null);
                 });
@@ -825,8 +824,7 @@ namespace JCertPreApplication.Persistence.Migrations
 
                     b.HasIndex("createdByUserId");
 
-                    b.HasIndex("lessonId")
-                        .IsUnique();
+                    b.HasIndex("lessonId");
 
                     b.HasIndex("status");
 
@@ -859,7 +857,7 @@ namespace JCertPreApplication.Persistence.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<Guid?>("testId")
+                    b.Property<Guid>("testId")
                         .HasColumnType("uuid");
 
                     b.Property<Guid>("userId")
@@ -1199,7 +1197,7 @@ namespace JCertPreApplication.Persistence.Migrations
                     b.HasOne("JCertPreApplication.Domain.Entities.Question", "Question")
                         .WithMany("AttemptAnswers")
                         .HasForeignKey("questionId")
-                        .OnDelete(DeleteBehavior.NoAction)
+                        .OnDelete(DeleteBehavior.SetNull)
                         .IsRequired();
 
                     b.Navigation("Choice");
@@ -1397,7 +1395,7 @@ namespace JCertPreApplication.Persistence.Migrations
                     b.HasOne("JCertPreApplication.Domain.Entities.Question", "Question")
                         .WithMany("QuestionAttachments")
                         .HasForeignKey("questionId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
 
                     b.Navigation("Question");
@@ -1435,11 +1433,6 @@ namespace JCertPreApplication.Persistence.Migrations
 
             modelBuilder.Entity("JCertPreApplication.Domain.Entities.StudyPlanItem", b =>
                 {
-                    b.HasOne("JCertPreApplication.Domain.Entities.TestTemplateType", "TestTemplateType")
-                        .WithMany("StudyPlanItems")
-                        .HasForeignKey("TestTemplateTypeId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.HasOne("JCertPreApplication.Domain.Entities.Course", "Course")
                         .WithMany("StudyPlanItems")
                         .HasForeignKey("courseId")
@@ -1451,11 +1444,16 @@ namespace JCertPreApplication.Persistence.Migrations
                         .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
 
+                    b.HasOne("JCertPreApplication.Domain.Entities.Test", "Test")
+                        .WithMany("StudyPlanItems")
+                        .HasForeignKey("testId")
+                        .OnDelete(DeleteBehavior.NoAction);
+
                     b.Navigation("Course");
 
                     b.Navigation("StudyPlan");
 
-                    b.Navigation("TestTemplateType");
+                    b.Navigation("Test");
                 });
 
             modelBuilder.Entity("JCertPreApplication.Domain.Entities.Test", b =>
@@ -1472,8 +1470,8 @@ namespace JCertPreApplication.Persistence.Migrations
                         .IsRequired();
 
                     b.HasOne("JCertPreApplication.Domain.Entities.Lesson", "Lesson")
-                        .WithOne("Test")
-                        .HasForeignKey("JCertPreApplication.Domain.Entities.Test", "lessonId")
+                        .WithMany("Tests")
+                        .HasForeignKey("lessonId")
                         .OnDelete(DeleteBehavior.NoAction);
 
                     b.Navigation("CreatedByUser");
@@ -1488,7 +1486,8 @@ namespace JCertPreApplication.Persistence.Migrations
                     b.HasOne("JCertPreApplication.Domain.Entities.Test", "Test")
                         .WithMany("TestAttempts")
                         .HasForeignKey("testId")
-                        .OnDelete(DeleteBehavior.NoAction);
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .IsRequired();
 
                     b.HasOne("JCertPreApplication.Domain.Entities.User", "User")
                         .WithMany("TestAttempts")
@@ -1506,7 +1505,7 @@ namespace JCertPreApplication.Persistence.Migrations
                     b.HasOne("JCertPreApplication.Domain.Entities.Question", "Question")
                         .WithMany("TestQuestions")
                         .HasForeignKey("questionId")
-                        .OnDelete(DeleteBehavior.NoAction)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("JCertPreApplication.Domain.Entities.Test", "Test")
@@ -1543,7 +1542,7 @@ namespace JCertPreApplication.Persistence.Migrations
                     b.HasOne("JCertPreApplication.Domain.Entities.TestTemplateType", "TestTemplateType")
                         .WithMany("TestTemplates")
                         .HasForeignKey("TestTemplateTypeId")
-                        .OnDelete(DeleteBehavior.Cascade)
+                        .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
                     b.Navigation("TestTemplateType");
@@ -1628,7 +1627,7 @@ namespace JCertPreApplication.Persistence.Migrations
 
                     b.Navigation("LessonProgresses");
 
-                    b.Navigation("Test");
+                    b.Navigation("Tests");
                 });
 
             modelBuilder.Entity("JCertPreApplication.Domain.Entities.Question", b =>
@@ -1661,6 +1660,8 @@ namespace JCertPreApplication.Persistence.Migrations
 
             modelBuilder.Entity("JCertPreApplication.Domain.Entities.Test", b =>
                 {
+                    b.Navigation("StudyPlanItems");
+
                     b.Navigation("TestAttempts");
 
                     b.Navigation("TestQuestions");
@@ -1682,8 +1683,6 @@ namespace JCertPreApplication.Persistence.Migrations
 
             modelBuilder.Entity("JCertPreApplication.Domain.Entities.TestTemplateType", b =>
                 {
-                    b.Navigation("StudyPlanItems");
-
                     b.Navigation("TestTemplates");
 
                     b.Navigation("Tests");

--- a/JCertPreApplication.Persistence/Migrations/20250822073528_TestTaken.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250822073528_TestTaken.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JCertPreApplication.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class TestTaken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_questions_sub_contents_SubContentId",
+                table: "questions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_test_template_config_sub_contents_subContentId",
+                table: "test_template_config");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "lastResetTestTime",
+                table: "student_profile",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "numberOfTestsTaken",
+                table: "student_profile",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_questions_sub_contents_SubContentId",
+                table: "questions",
+                column: "SubContentId",
+                principalTable: "sub_contents",
+                principalColumn: "SubContentId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_test_template_config_sub_contents_subContentId",
+                table: "test_template_config",
+                column: "subContentId",
+                principalTable: "sub_contents",
+                principalColumn: "SubContentId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_questions_sub_contents_SubContentId",
+                table: "questions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_test_template_config_sub_contents_subContentId",
+                table: "test_template_config");
+
+            migrationBuilder.DropColumn(
+                name: "lastResetTestTime",
+                table: "student_profile");
+
+            migrationBuilder.DropColumn(
+                name: "numberOfTestsTaken",
+                table: "student_profile");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_questions_sub_contents_SubContentId",
+                table: "questions",
+                column: "SubContentId",
+                principalTable: "sub_contents",
+                principalColumn: "SubContentId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_test_template_config_sub_contents_subContentId",
+                table: "test_template_config",
+                column: "subContentId",
+                principalTable: "sub_contents",
+                principalColumn: "SubContentId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Migrations/20250822080810_DeleteBehavior&StudyPlanItem.Designer.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250822080810_DeleteBehavior&StudyPlanItem.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JCertPreApplication.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JCertPreApplication.Persistence.Migrations
 {
     [DbContext(typeof(JCertPreDatabaseContext))]
-    partial class JCertPreDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250822080810_DeleteBehavior&StudyPlanItem")]
+    partial class DeleteBehaviorStudyPlanItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -825,8 +828,7 @@ namespace JCertPreApplication.Persistence.Migrations
 
                     b.HasIndex("createdByUserId");
 
-                    b.HasIndex("lessonId")
-                        .IsUnique();
+                    b.HasIndex("lessonId");
 
                     b.HasIndex("status");
 
@@ -1472,8 +1474,8 @@ namespace JCertPreApplication.Persistence.Migrations
                         .IsRequired();
 
                     b.HasOne("JCertPreApplication.Domain.Entities.Lesson", "Lesson")
-                        .WithOne("Test")
-                        .HasForeignKey("JCertPreApplication.Domain.Entities.Test", "lessonId")
+                        .WithMany("Tests")
+                        .HasForeignKey("lessonId")
                         .OnDelete(DeleteBehavior.NoAction);
 
                     b.Navigation("CreatedByUser");
@@ -1628,7 +1630,7 @@ namespace JCertPreApplication.Persistence.Migrations
 
                     b.Navigation("LessonProgresses");
 
-                    b.Navigation("Test");
+                    b.Navigation("Tests");
                 });
 
             modelBuilder.Entity("JCertPreApplication.Domain.Entities.Question", b =>

--- a/JCertPreApplication.Persistence/Migrations/20250822080810_DeleteBehavior&StudyPlanItem.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250822080810_DeleteBehavior&StudyPlanItem.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JCertPreApplication.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeleteBehaviorStudyPlanItem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_attempt_answer_questions_questionId",
+                table: "attempt_answer");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_question_attachment_questions_questionId",
+                table: "question_attachment");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_study_plan_item_test_testId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_test_question_questions_questionId",
+                table: "test_question");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_test_template_test_template_type_TestTemplateTypeId",
+                table: "test_template");
+
+            migrationBuilder.RenameColumn(
+                name: "testId",
+                table: "study_plan_item",
+                newName: "TestTemplateTypeId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_study_plan_item_testId",
+                table: "study_plan_item",
+                newName: "IX_study_plan_item_TestTemplateTypeId");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "testId",
+                table: "test_attempt",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<string>(
+                name: "description",
+                table: "study_plan_item",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_attempt_answer_questions_questionId",
+                table: "attempt_answer",
+                column: "questionId",
+                principalTable: "questions",
+                principalColumn: "questionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_question_attachment_questions_questionId",
+                table: "question_attachment",
+                column: "questionId",
+                principalTable: "questions",
+                principalColumn: "questionId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_study_plan_item_test_template_type_TestTemplateTypeId",
+                table: "study_plan_item",
+                column: "TestTemplateTypeId",
+                principalTable: "test_template_type",
+                principalColumn: "TestTemplateTypeId",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_test_question_questions_questionId",
+                table: "test_question",
+                column: "questionId",
+                principalTable: "questions",
+                principalColumn: "questionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_test_template_test_template_type_TestTemplateTypeId",
+                table: "test_template",
+                column: "TestTemplateTypeId",
+                principalTable: "test_template_type",
+                principalColumn: "TestTemplateTypeId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_attempt_answer_questions_questionId",
+                table: "attempt_answer");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_question_attachment_questions_questionId",
+                table: "question_attachment");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_study_plan_item_test_template_type_TestTemplateTypeId",
+                table: "study_plan_item");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_test_question_questions_questionId",
+                table: "test_question");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_test_template_test_template_type_TestTemplateTypeId",
+                table: "test_template");
+
+            migrationBuilder.DropColumn(
+                name: "description",
+                table: "study_plan_item");
+
+            migrationBuilder.RenameColumn(
+                name: "TestTemplateTypeId",
+                table: "study_plan_item",
+                newName: "testId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_study_plan_item_TestTemplateTypeId",
+                table: "study_plan_item",
+                newName: "IX_study_plan_item_testId");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "testId",
+                table: "test_attempt",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_attempt_answer_questions_questionId",
+                table: "attempt_answer",
+                column: "questionId",
+                principalTable: "questions",
+                principalColumn: "questionId",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_question_attachment_questions_questionId",
+                table: "question_attachment",
+                column: "questionId",
+                principalTable: "questions",
+                principalColumn: "questionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_study_plan_item_test_testId",
+                table: "study_plan_item",
+                column: "testId",
+                principalTable: "test",
+                principalColumn: "testId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_test_question_questions_questionId",
+                table: "test_question",
+                column: "questionId",
+                principalTable: "questions",
+                principalColumn: "questionId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_test_template_test_template_type_TestTemplateTypeId",
+                table: "test_template",
+                column: "TestTemplateTypeId",
+                principalTable: "test_template_type",
+                principalColumn: "TestTemplateTypeId",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Migrations/20250822085330_RelationShip.Designer.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250822085330_RelationShip.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JCertPreApplication.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JCertPreApplication.Persistence.Migrations
 {
     [DbContext(typeof(JCertPreDatabaseContext))]
-    partial class JCertPreDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250822085330_RelationShip")]
+    partial class RelationShip
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JCertPreApplication.Persistence/Migrations/20250822085330_RelationShip.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250822085330_RelationShip.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JCertPreApplication.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RelationShip : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_test_lessonId",
+                table: "test");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_test_lessonId",
+                table: "test",
+                column: "lessonId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_test_lessonId",
+                table: "test");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_test_lessonId",
+                table: "test",
+                column: "lessonId");
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Repositories/EnrollmentRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/EnrollmentRepository.cs
@@ -49,6 +49,11 @@ namespace JCertPreApplication.Persistence.Repositories
                 .AnyAsync(e => e.userId == userId && e.courseId == courseId);
         }
 
+        public async Task<bool> IsUserEnrolledInAnyCourseAsync(Guid userId)
+        {
+            return await _context.Enrollments.AnyAsync(e => e.userId == userId);
+        }
+
         public async Task<long> GetTotalEnrollmentsCountAsync()
         {
             return await _context.Enrollments.LongCountAsync();
@@ -70,4 +75,4 @@ namespace JCertPreApplication.Persistence.Repositories
                 .LongCountAsync();
         }
     }
-} 
+}

--- a/JCertPreApplication.Persistence/Repositories/StudyPlanItemRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/StudyPlanItemRepository.cs
@@ -23,7 +23,7 @@ namespace JCertPreApplication.Persistence.Repositories
             return await _context.StudyPlanItems
                 .Include(spi => spi.StudyPlan)
                 .Include(spi => spi.Course)
-                .Include(spi => spi.Test)
+                .Include(spi => spi.TestTemplateType)
                 .FirstOrDefaultAsync(spi => spi.itemId == itemId);
         }
 
@@ -33,7 +33,7 @@ namespace JCertPreApplication.Persistence.Repositories
                 .Where(spi => spi.planId == planId)
                 .Include(spi => spi.StudyPlan)
                 .Include(spi => spi.Course)
-                .Include(spi => spi.Test)
+                .Include(spi => spi.TestTemplateType)
                 .OrderBy(spi => spi.sequence) // Order by sequence for logical retrieval
                 .ToListAsync();
         }

--- a/JCertPreApplication.Persistence/Repositories/StudyPlanRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/StudyPlanRepository.cs
@@ -26,7 +26,7 @@ namespace JCertPreApplication.Persistence.Repositories
                 .Include(sp => sp.StudyPlanItems)
                     .ThenInclude(spi => spi.Course)
                 .Include(sp => sp.StudyPlanItems)
-                    .ThenInclude(spi => spi.Test)
+                    .ThenInclude(spi => spi.TestTemplateType)
                 .FirstOrDefaultAsync(sp => sp.planId == planId);
         }
 


### PR DESCRIPTION
This pull request introduces a new validation attribute for test types, standardizes the usage of DTO utility classes, and refactors study plan item models to use a more descriptive property for test template types. Additionally, it updates repository contracts to support new enrollment queries.

**Validation and DTO Utilities:**

* Added `AllowedTestTypeAttribute` in `JCertPreApplication.Application.Dtos.Utilities` to validate that `TestType` is either `JLPTAuto` or `EntryAuto`, and applied this validation to `CreateAutoTestInput`. [[1]](diffhunk://#diff-ad1f91a9bbfc33961cf3b3ea976c4c4c5a26e54988be92cc2a54de4e741acf02R1-R22) [[2]](diffhunk://#diff-0667aaadb0aae42c3a920b3556f2fe6e62cf84fad90f8fd9372174c6b690730cR2-R10)
* Moved `EnumValueDto` and `NotDefaultGuidAttribute` into the `JCertPreApplication.Application.Dtos.Utilities` namespace and updated all DTOs and services to use the new namespace for utility classes. [[1]](diffhunk://#diff-27ebd39177e5183a555624313fae7b24781e1d6d8c29b8a9677979489dbff468L1-R1) [[2]](diffhunk://#diff-0c8b8aed028c7d1fff29c1d3be0230bdae7108e72b1359bd75c2a21777627baaL3-R3) [[3]](diffhunk://#diff-0e26e7a94aeeb476d467590883f4d62723baf2def93c6218ef426cf39a3c3eaeR1) [[4]](diffhunk://#diff-73f2a4e89f064fb84b1a4a2760866ad8f08f9f967385d78560ad846c656e4d2aR1) [[5]](diffhunk://#diff-4a6b269b6ac2373639efde6f6b26d2944796b36da82cba236da91cd9a112bbb1R2) [[6]](diffhunk://#diff-1448c49cac05b0d4c9eca150e6f73c78be945559b7503a383ad261858e97aa40R1) [[7]](diffhunk://#diff-bf8c9d91915f1cd36016a503edf7af5028bd47831c9b3bf2756763e9e49731f8R1) [[8]](diffhunk://#diff-77813ff8cc02e2012440309bae0b3212ecae4b0afc357b549673ac73268dee13R1) [[9]](diffhunk://#diff-dfa269b072fc83c07fe67dec3017c5b7f8faedcfa2443560f22b6350a534b484R1) [[10]](diffhunk://#diff-ea9f971a54b1d79ffb888f6fc7671216ab9640ac93dec77811166308276e8afbR1) [[11]](diffhunk://#diff-37115c4b21f6b4e2a1f04b8a44b89e38455944574b2fbc0acb0a659242ceccfcR1) [[12]](diffhunk://#diff-557c8c91e154f77a2c4734d13d29a5f91f803c84954dbbf11e1e7250f337a04dR2-L3) [[13]](diffhunk://#diff-ee0d904c46381ca3b06711d75fac061bd7bae66069e39d1cdd0d14080d6faf58L1-R2) [[14]](diffhunk://#diff-bf67a7f917c8bd8ed9b3959a63dfbe20fb0c659312661f04200c370de025a429L2-R3)

**Study Plan Item Refactor:**

* Replaced `TestId` with `TestTemplateTypeId` in `StudyPlanItemDto`, `UpdateStudyPlanItemDto`, and all related mapping/service logic to improve clarity and alignment with domain concepts. [[1]](diffhunk://#diff-aa57d9e0870d41a5ad64d5424eb62ce3cfe6162e97a403327affe37a588f4bbdL12-R12) [[2]](diffhunk://#diff-966a153b34623ea84bd986c5e2ed115797c848a7e6c76c4d2825d454ae9cd729L10-R10) [[3]](diffhunk://#diff-9b13caf7a2c0bce4fe953570424a1d45f2e012475e43e2e62c53f4ea5311a25dL32-R32) [[4]](diffhunk://#diff-9b13caf7a2c0bce4fe953570424a1d45f2e012475e43e2e62c53f4ea5311a25dL70-R71) [[5]](diffhunk://#diff-9b13caf7a2c0bce4fe953570424a1d45f2e012475e43e2e62c53f4ea5311a25dL97-R97)

**Repository Contract Update:**

* Added `IsUserEnrolledInAnyCourseAsync` to the `IEnrollmentRepository` interface to support checking if a user is enrolled in any course.