### PR TITLE
fix: point per question

### DIFF
--- a/JCertPreApplication.Application/Features/Questions/QuestionService.cs
+++ b/JCertPreApplication.Application/Features/Questions/QuestionService.cs
@@ -588,7 +588,7 @@ namespace JCertPreApplication.Application.Features.Questions
                 var questionIds = await _questionRepository.GetRandomQuestionIdsAsync(
                     subContent.SubContentId,
                     requestDto.NumberOfQuestions,
-                    pointPerQuestion: 0 // or set as needed
+                    pointPerQuestion: 2 // or set as needed
                 );
                 if (questionIds == null || questionIds.Count == 0)
                     return new List<RandomQuestionWithChoicesDto>();


### PR DESCRIPTION
This pull request makes a targeted change to the logic for fetching random questions in the `QuestionService`. The point value per question has been updated to ensure each selected question is worth 2 points instead of 0.

- Updated the `pointPerQuestion` parameter from 0 to 2 in the call to `_questionRepository.GetRandomQuestionIdsAsync` within `GetRandomQuestionsWithChoi`, so that randomly selected questions now have a point value of 2.