### PR TITLE
refactor: change file and firebase service registration to singleton …

### DIFF
--- a/JCertPreApplication.Persistence/DependencyInjection.cs
+++ b/JCertPreApplication.Persistence/DependencyInjection.cs
@@ -82,8 +82,8 @@ namespace JCertPreApplication.Persistence
             services.AddScoped<IAIIntegration, GeminiService>();
 
             // Infrastructure Services - File Service using Appwrite
-            services.AddScoped<IFileService, AppwriteFileService>();
-            services.AddScoped<IFirebaseService, FirebaseService>();
+            services.AddSingleton<IFileService, AppwriteFileService>();
+            services.AddSingleton<IFirebaseService, FirebaseService>();
             services.AddScoped<ILiveKitService, Services.LiveKit.LiveKitService>();
             services.AddSingleton<IPasswordService, PasswordService>();
 


### PR DESCRIPTION
This pull request updates the dependency injection configuration for infrastructure services in the `JCertPreApplication.Persistence/DependencyInjection.cs` file. The main change is to adjust the lifetimes of two services to ensure they are instantiated as singletons rather than being created per request.

**Dependency injection configuration updates:**

* Changed the lifetime of `IFileService` (implemented by `AppwriteFileService`) from scoped to singleton, ensuring only one instance is created for the application's lifetime.
* Changed the lifetime of `IFirebaseService` (implemented by `FirebaseService`) from scoped to singleton, so it is shared across all requests.…scope in DependencyInjection