### PR TITLE
feat: create personal course

### DIFF
--- a/JCertPreApplication.API/Controllers/CoursesController.cs
+++ b/JCertPreApplication.API/Controllers/CoursesController.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using JCertPreApplication.Application.Dtos.Course;
+using JCertPreApplication.Application.Exceptions;
 using JCertPreApplication.Application.Features.Course;
 using JCertPreApplication.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
@@ -174,5 +176,41 @@ namespace JCertPreApplication.API.Controllers
             var courses = await _courseService.GetCoursesByStudentAsync(studentId);
             return Ok(courses);
         }
+
+        /// <summary>
+        /// Creates a personal course for a user.
+        /// </summary>
+        [HttpPost("personal/{userPersonalId}")]
+        [Consumes("multipart/form-data")]
+        [Authorize(Roles = "ACADEMIC_MANAGER")]
+        public async Task<IActionResult> CreatePersonalCourse([FromRoute] Guid userPersonalId, [FromForm] CreateCourseDto createCourseDto)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var course = await _courseService.CreatePersonalCourseAsync(createCourseDto, userPersonalId);
+            return CreatedAtAction(nameof(GetCourse), new { id = course.CourseId }, course);
+        }
+
+        /// <summary>
+        /// Gets a personal course by courseId (only owner or academic manager can access).
+        /// </summary>
+        [HttpGet("personal/detail/{courseId}")]
+        [Authorize(Roles = "STUDENT,INSTRUCTOR,ACADEMIC_MANAGER")]
+        public async Task<IActionResult> GetPersonalCourse([FromRoute] Guid courseId)
+        {
+            var course = await _courseService.GetPersonalCourseByUserAsync(courseId, User);
+            return Ok(course);
+        }
+        /// <summary>
+        /// Gets all personal courses for a user (only owner or academic manager can access).
+        /// </summary>
+        [HttpGet("personal/list/{userPersonalId}")]
+        [Authorize(Roles = "STUDENT,INSTRUCTOR,ACADEMIC_MANAGER")]
+        public async Task<IActionResult> GetPersonalCourses([FromRoute] Guid userPersonalId)
+        {
+            var result = await _courseService.GetPersonalCoursesByUserAsync(userPersonalId, User);
+            return Ok(result);
+        }
     }
-} 
+}

--- a/JCertPreApplication.Application/Features/Course/CourseService.cs
+++ b/JCertPreApplication.Application/Features/Course/CourseService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using JCertPreApplication.Application.Contracts;
 using JCertPreApplication.Application.Dtos.Course;
 using JCertPreApplication.Application.Dtos.User;
@@ -332,6 +333,131 @@ namespace JCertPreApplication.Application.Features.Course
             return courses.Select(MapToCourseListDto);
         }
 
+        /// <summary>
+        /// Create a personal course for a specific user.
+        /// </summary>
+        /// <param name="createCourseDto">Course creation data</param>
+        /// <param name="userPersonalId">User ID for whom the course is personal</param>
+        /// <returns>Created CourseDto</returns>
+        public async Task<CourseDto> CreatePersonalCourseAsync(CreateCourseDto createCourseDto, Guid userPersonalId)
+        {
+            try
+            {
+
+                // Check if title is unique
+                if (!await _courseRepository.IsTitleUniqueAsync(createCourseDto.Title))
+                    throw ApiException.BadRequest("COURSE_TITLE_EXISTS", "A course with this title already exists");
+
+                var courseId = Guid.NewGuid();
+                string? thumbnailUrl = null;
+
+                if (createCourseDto.ThumbnailFile != null)
+                {
+                    var customFormFile = CreateCustomFormFile(createCourseDto.ThumbnailFile, courseId.ToString());
+                    var uploadResult = await _fileService.UploadImageAsync(customFormFile);
+                    if (uploadResult.Success && !string.IsNullOrEmpty(uploadResult.Url))
+                    {
+                        thumbnailUrl = uploadResult.SecureUrl ?? uploadResult.Url;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Failed to upload thumbnail: {uploadResult.ErrorMessage}");
+                    }
+                }
+
+                var course = new Domain.Entities.Course
+                {
+                    courseId = courseId,
+                    title = createCourseDto.Title,
+                    description = createCourseDto.Description,
+                    level = createCourseDto.Level,
+                    courseType = createCourseDto.CourseType,
+                    price = createCourseDto.Price,
+                    thumbnailUrl = thumbnailUrl,
+                    status = CourseStatus.Draft,
+                    createdAt = DateTime.UtcNow,
+                    startDate = createCourseDto.StartDate,
+                    endDate = createCourseDto.EndDate,
+                    userPersonal = userPersonalId // Set personal user
+                };
+
+                await _courseRepository.InsertAsync(course);
+                await _courseRepository.SaveChangesAsync();
+
+                return MapToCourseDto(course);
+            }
+            catch (ApiException) { throw; }
+            catch (Exception ex)
+            {
+                throw ApiException.InternalServerError("PERSONAL_COURSE_CREATE_ERROR", $"An error occurred while creating the personal course: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Get a personal course by courseId, with claim/role check.
+        /// Returns a detailed CourseDto (with navigation properties).
+        /// </summary>
+        /// <param name="courseId">Course ID to get</param>
+        /// <param name="user">ClaimsPrincipal of the logged-in user</param>
+        /// <returns>CourseDto</returns>
+        public async Task<CourseDto> GetPersonalCourseByUserAsync(Guid courseId, ClaimsPrincipal user)
+        {
+            try
+            {
+                var course = await _courseRepository.GetCourseWithDetailsAsync(courseId);
+                if (course == null)
+                    throw ApiException.NotFound("Course", courseId);
+
+                // Only allow if user is owner or academic manager
+                var loggedUserId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                var role = user.FindFirst(ClaimTypes.Role)?.Value;
+
+                if (course.userPersonal == null)
+                    throw ApiException.BadRequest("NOT_PERSONAL_COURSE", "This course is not a personal course.");
+
+                if (role != "ACADEMIC_MANAGER" && loggedUserId != course.userPersonal.ToString())
+                    throw ApiException.Forbidden("FORBIDDEN", "You are not allowed to view this personal course.");
+
+                return MapToCourseDto(course);
+            }
+            catch (ApiException) { throw; }
+            catch (Exception ex)
+            {
+                throw ApiException.InternalServerError("GET_PERSONAL_COURSE_ERROR", $"An error occurred while getting the personal course: {ex.Message}");
+            }
+        }
+        /// <summary>
+        /// Get all personal courses for a user, with claim/role check.
+        /// Returns a list of detailed CourseDto (with navigation properties).
+        /// </summary>
+        /// <param name="userPersonalId">User ID to get personal courses for</param>
+        /// <param name="user">ClaimsPrincipal of the logged-in user</param>
+        /// <returns>List of CourseDto</returns>
+        public async Task<IEnumerable<CourseDto>> GetPersonalCoursesByUserAsync(Guid userPersonalId, ClaimsPrincipal user)
+        {
+            try
+            {
+                var loggedUserId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                var role = user.FindFirst(ClaimTypes.Role)?.Value;
+
+                if (role != "ACADEMIC_MANAGER" && loggedUserId != userPersonalId.ToString())
+                    throw ApiException.Forbidden("FORBIDDEN", "You are not allowed to view these personal courses.");
+
+                // Get all personal courses for the user, including navigation properties
+                var courses = await _courseRepository.GetAllAsync(
+                    c => c.userPersonal == userPersonalId,
+                    includeProperties: "Lessons,CourseInstructors.Instructor,Enrollments,Feedbacks"
+                );
+
+                // Map each course to a detailed CourseDto
+                return courses.Select(MapToCourseDto).ToList();
+            }
+            catch (ApiException) { throw; }
+            catch (Exception ex)
+            {
+                throw ApiException.InternalServerError("GET_PERSONAL_COURSE_LIST_ERROR", $"An error occurred while getting personal courses: {ex.Message}");
+            }
+        }
         private static CourseDto MapToCourseDto(Domain.Entities.Course course)
         {
             return new CourseDto

--- a/JCertPreApplication.Application/Features/Course/ICourseService.cs
+++ b/JCertPreApplication.Application/Features/Course/ICourseService.cs
@@ -2,6 +2,7 @@ using JCertPreApplication.Application.Dtos.Course;
 using JCertPreApplication.Application.Dtos.User;
 using JCertPreApplication.Application.Utilities;
 using JCertPreApplication.Domain.Enums;
+using System.Security.Claims;
 
 namespace JCertPreApplication.Application.Features.Course
 {
@@ -19,5 +20,8 @@ namespace JCertPreApplication.Application.Features.Course
         Task<IEnumerable<CourseInstructorHistoryDto>> GetCourseInstructorHistoryAsync(Guid courseId);
         Task<IEnumerable<CourseListDto>> GetCoursesByInstructorAsync(Guid instructorId);
         Task<IEnumerable<CourseListDto>> GetCoursesByStudentAsync(Guid studentId);
+        Task<CourseDto> CreatePersonalCourseAsync(CreateCourseDto createCourseDto, Guid userPersonalId);
+        Task<CourseDto> GetPersonalCourseByUserAsync(Guid courseId, ClaimsPrincipal user);
+        Task<IEnumerable<CourseDto>> GetPersonalCoursesByUserAsync(Guid userPersonalId, ClaimsPrincipal user);
     }
-} 
+}

--- a/JCertPreApplication.Application/Features/TestTemplateConfigs/TestTemplateConfigService.cs
+++ b/JCertPreApplication.Application/Features/TestTemplateConfigs/TestTemplateConfigService.cs
@@ -70,6 +70,12 @@ namespace JCertPreApplication.Application.Features.TestTemplateConfigs
                 if (isTypeActive)
                     throw ApiException.BadRequest("TYPE_ACTIVE", "Cannot perform this operation because the test template type is active.");
 
+                // --- Duplicate subContentId check across all templates of the same type ---
+                var allTemplates = await _templateRepo.GetAllAsync(t => t.TestTemplateTypeId == template.TestTemplateTypeId, "TestTemplateConfigs");
+                var allConfigs = allTemplates.SelectMany(t => t.TestTemplateConfigs).ToList();
+                if (allConfigs.Any(c => c.subContentId == dto.subContentId))
+                    throw ApiException.BadRequest("DUPLICATE_SUBCONTENT", "Duplicate subContentId found in another test template of the same type.");
+
                 // Efficiently check if there are enough questions in DB for this subContentId
                 var availableCount = await _questionRepo.CountAsync(q =>
                     q.SubContentId == dto.subContentId && q.isActive);

--- a/JCertPreApplication.Domain/Entities/Course.cs
+++ b/JCertPreApplication.Domain/Entities/Course.cs
@@ -11,6 +11,7 @@ namespace JCertPreApplication.Domain.Entities
         public CourseType courseType { get; set; }
         public decimal price { get; set; }
         public string? thumbnailUrl { get; set; }
+        public Guid? userPersonal { get; set; }
         public CourseStatus status { get; set; }
         public DateTime createdAt { get; set; }
         public DateTime startDate { get; set; }  // New field

--- a/JCertPreApplication.Persistence/Configurations/CourseConfiguration.cs
+++ b/JCertPreApplication.Persistence/Configurations/CourseConfiguration.cs
@@ -24,6 +24,8 @@ namespace JCertPreApplication.Persistence.Configurations
             builder.Property(c => c.startDate).IsRequired();
             builder.Property(c => c.endDate).IsRequired();
 
+            builder.Property(c => c.userPersonal).IsRequired(false); // <-- Added configuration
+
             // Configure relationship with instructors through CourseInstructor
             builder.HasMany(c => c.CourseInstructors)
                    .WithOne(ci => ci.Course)

--- a/JCertPreApplication.Persistence/Migrations/20250901032924_PersonalCourse.Designer.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250901032924_PersonalCourse.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using JCertPreApplication.Persistence.DatabaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace JCertPreApplication.Persistence.Migrations
 {
     [DbContext(typeof(JCertPreDatabaseContext))]
-    partial class JCertPreDatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20250901032924_PersonalCourse")]
+    partial class PersonalCourse
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/JCertPreApplication.Persistence/Migrations/20250901032924_PersonalCourse.cs
+++ b/JCertPreApplication.Persistence/Migrations/20250901032924_PersonalCourse.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace JCertPreApplication.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class PersonalCourse : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "userPersonal",
+                table: "course",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "userPersonal",
+                table: "course");
+        }
+    }
+}

--- a/JCertPreApplication.Persistence/Repositories/CourseRepository.cs
+++ b/JCertPreApplication.Persistence/Repositories/CourseRepository.cs
@@ -38,6 +38,9 @@ namespace JCertPreApplication.Persistence.Repositories
                 .Include(c => c.Enrollments)
                 .AsQueryable();
 
+            // Filter out courses with userPersonal not null
+            query = query.Where(c => c.userPersonal == null);
+
             // Apply search filter
             if (!string.IsNullOrEmpty(queryParameters.SearchTerm))
             {
@@ -197,4 +200,4 @@ namespace JCertPreApplication.Persistence.Repositories
                 .ToListAsync();
         }
     }
-} 
+}


### PR DESCRIPTION
This pull request introduces the concept of "personal courses" to the application, allowing users (such as students or instructors) to create and manage courses that are associated specifically with their user account. It includes API endpoints, service methods, database schema changes, and access control to support this feature. Additionally, a validation improvement is made for test template configuration.

**Personal Course Feature Implementation:**

* Added a new nullable `userPersonal` property to the `Course` entity and database schema to indicate ownership of a personal course. This is supported by a new migration and updated entity configuration. [[1]](diffhunk://#diff-207bd5918d822a3dae199d5b40f1688c49ab034813ea2ae7e49710a63df00d9dR14) [[2]](diffhunk://#diff-e7d8f935db6fdadaa4a5c6ce7ca6664b2ab91ad38ca05fd49936ff719a54d375R27-R28) [[3]](diffhunk://#diff-e334a12ab91124e26a59d2587312e7d26f5ffb9ef517180b1c05b5139bb7140aR1-R29) [[4]](diffhunk://#diff-370472711cecc8cb1e3f248d196d9b89ad2a57945d8ce0651aaf4dfced86dae9R166-R168)
* Updated the `CourseRepository` so that standard course queries exclude personal courses by default.

**API and Service Layer Enhancements:**

* Added new API endpoints in `CoursesController` for creating a personal course, retrieving a specific personal course, and listing all personal courses for a user, with appropriate role-based authorization.
* Implemented service methods in `CourseService` to handle creation and retrieval of personal courses, including ownership and role checks, and updated the interface accordingly. [[1]](diffhunk://#diff-a04d99896e2e28d3c070bdc276817b2c866e9f80534c4f14fa29e412130b3311R336-R460) [[2]](diffhunk://#diff-4a69ba7da8cb909e19852cab29e498c26d409cdc3e24b5ec2c342e47278dc4e8R23-R25) [[3]](diffhunk://#diff-a04d99896e2e28d3c070bdc276817b2c866e9f80534c4f14fa29e412130b3311R1) [[4]](diffhunk://#diff-4a69ba7da8cb909e19852cab29e498c26d409cdc3e24b5ec2c342e47278dc4e8R5)

**Validation Improvements:**

* Improved validation in `TestTemplateConfigService` to prevent duplicate `subContentId` values across all templates of the same type, not just within a single template.