### PR TITLE
fix: study plan and enrollment

### DIFF
--- a/JCertPreApplication.API/Controllers/StudyPlanItemsController.cs
+++ b/JCertPreApplication.API/Controllers/StudyPlanItemsController.cs
@@ -32,17 +32,18 @@ namespace JCertPreApplication.API.Controllers
         /// <param name="courseId">Optional course ID.</param>
         /// <param name="testId">Optional test ID.</param>
         /// <param name="status">Item status.</param>
+        /// <param name="description">Item description.</param>
         /// <returns>Created study plan item.</returns>
         [HttpPost("create")]
         [Authorize(Roles = "STUDENT,ACADEMIC_MANAGER")]
-        public async Task<IActionResult> CreateStudyPlanItem(Guid planId, int sequence, string itemType, Guid? courseId, Guid? testId, ItemStatus status)
+        public async Task<IActionResult> CreateStudyPlanItem(Guid planId, int sequence, string itemType, Guid? courseId, Guid? testId, ItemStatus status, string description)
         {
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
 
-            var createdStudyPlanItem = await _studyPlanItemService.CreateStudyPlanItemAsync(planId, sequence, itemType, courseId, testId, status);
+            var createdStudyPlanItem = await _studyPlanItemService.CreateStudyPlanItemAsync(planId, sequence, itemType, courseId, testId, status, description);
             return CreatedAtAction(nameof(GetStudyPlanItemById), new { itemId = createdStudyPlanItem.ItemId }, createdStudyPlanItem);
         }
 

--- a/JCertPreApplication.Application/Dtos/StudyPlan/StudyPlanItemDto.cs
+++ b/JCertPreApplication.Application/Dtos/StudyPlan/StudyPlanItemDto.cs
@@ -11,5 +11,6 @@ namespace JCertPreApplication.Application.Dtos.StudyPlan
         public Guid? CourseId { get; set; }
         public Guid? TestTemplateTypeId { get; set; }
         public ItemStatus Status { get; set; }
+        public string? Description { get; set; } // <-- Added
     }
 }

--- a/JCertPreApplication.Application/Dtos/StudyPlan/UpdateStudyPlanItemDto.cs
+++ b/JCertPreApplication.Application/Dtos/StudyPlan/UpdateStudyPlanItemDto.cs
@@ -9,5 +9,6 @@ namespace JCertPreApplication.Application.Dtos.StudyPlan
         public Guid? CourseId { get; set; }
         public Guid? TestTemplateTypeId { get; set; }
         public ItemStatus? Status { get; set; }
+        public string? Description { get; set; } // <-- Added
     }
 } 

--- a/JCertPreApplication.Application/Features/Enrollment/EnrollmentService.cs
+++ b/JCertPreApplication.Application/Features/Enrollment/EnrollmentService.cs
@@ -35,7 +35,7 @@ namespace JCertPreApplication.Application.Features.Enrollment
             // 1. Validate input
             if (userId == Guid.Empty)
                 throw ApiException.BadRequest("INVALID_USER_ID", "User ID cannot be empty");
-            
+
             if (courseId == Guid.Empty)
                 throw ApiException.BadRequest("INVALID_COURSE_ID", "Course ID cannot be empty");
 
@@ -47,6 +47,13 @@ namespace JCertPreApplication.Application.Features.Enrollment
             var course = await _courseRepository.GetByIdAsync(courseId);
             if (course == null)
                 throw ApiException.NotFound("COURSE_NOT_FOUND", "Course not found");
+
+            // --- PERSONAL COURSE ENROLLMENT CHECK ---
+            if (course.userPersonal.HasValue)
+            {
+                if (course.userPersonal.Value != userId)
+                    throw ApiException.Forbidden("PERSONAL_COURSE_FORBIDDEN", "You are not allowed to enroll in this personal course.");
+            }
 
             // 3. Check if user is already enrolled
             var isAlreadyEnrolled = await _enrollmentRepository.IsUserEnrolledAsync(userId, courseId);
@@ -63,7 +70,7 @@ namespace JCertPreApplication.Application.Features.Enrollment
             {
                 var currentCredit = user.credit;
                 var requiredCredit = (int)Math.Ceiling(course.price);
-                throw ApiException.BadRequest("INSUFFICIENT_CREDIT", 
+                throw ApiException.BadRequest("INSUFFICIENT_CREDIT",
                     $"Insufficient credit. Required: {requiredCredit}, Available: {currentCredit}");
             }
 
@@ -71,9 +78,9 @@ namespace JCertPreApplication.Application.Features.Enrollment
             {
                 // 6. Process payment using PaymentService
                 var paymentResult = await _paymentService.ProcessCreditPaymentAsync(
-                    userId, 
-                    courseId, 
-                    course.price, 
+                    userId,
+                    courseId,
+                    course.price,
                     $"Course enrollment: {course.title}");
 
                 if (!paymentResult.IsSuccess)
@@ -94,7 +101,7 @@ namespace JCertPreApplication.Application.Features.Enrollment
                 await _enrollmentRepository.InsertAsync(enrollment);
                 await _enrollmentRepository.SaveChangesAsync();
 
-                _logger.LogInformation("Successfully enrolled user {UserId} in course {CourseId} with payment {PaymentId}", 
+                _logger.LogInformation("Successfully enrolled user {UserId} in course {CourseId} with payment {PaymentId}",
                     userId, courseId, paymentResult.PaymentId);
 
                 // 8. Return response

--- a/JCertPreApplication.Application/Features/StudyPlanItem/IStudyPlanItemService.cs
+++ b/JCertPreApplication.Application/Features/StudyPlanItem/IStudyPlanItemService.cs
@@ -5,7 +5,7 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
 {
     public interface IStudyPlanItemService
     {
-        Task<StudyPlanItemDto> CreateStudyPlanItemAsync(Guid planId, int sequence, string itemType, Guid? courseId, Guid? testId, ItemStatus status);
+        Task<StudyPlanItemDto> CreateStudyPlanItemAsync(Guid planId, int sequence, string itemType, Guid? courseId, Guid? testId, ItemStatus status, string description);
         Task<StudyPlanItemDto> GetStudyPlanItemByIdAsync(Guid itemId);
         Task<IEnumerable<StudyPlanItemDto>> GetStudyPlanItemsByPlanIdAsync(Guid planId);
         Task<StudyPlanItemDto> UpdateStudyPlanItemAsync(Guid itemId, UpdateStudyPlanItemDto updateDto);

--- a/JCertPreApplication.Application/Features/StudyPlanItem/StudyPlanItemService.cs
+++ b/JCertPreApplication.Application/Features/StudyPlanItem/StudyPlanItemService.cs
@@ -16,7 +16,7 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
             _studyPlanRepository = studyPlanRepository ?? throw new ArgumentNullException(nameof(studyPlanRepository));
         }
 
-        public async Task<StudyPlanItemDto> CreateStudyPlanItemAsync(Guid planId, int sequence, string itemType, Guid? courseId, Guid? testId, ItemStatus status)
+        public async Task<StudyPlanItemDto> CreateStudyPlanItemAsync(Guid planId, int sequence, string itemType, Guid? courseId, Guid? testId, ItemStatus status, string description)
         {
             var studyPlanExists = await _studyPlanRepository.GetStudyPlanByIdAsync(planId);
             if (studyPlanExists == null)
@@ -30,7 +30,8 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
                 itemType = itemType,
                 courseId = courseId,
                 TestTemplateTypeId = testId,
-                status = status
+                status = status,
+                description = description // or set from input if you add it to the method signature
             };
             await _studyPlanItemRepository.CreateStudyPlanItemAsync(studyPlanItem);
             return MapToStudyPlanItemDto(studyPlanItem);
@@ -71,6 +72,8 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
                 existingItem.TestTemplateTypeId = updateDto.TestTemplateTypeId;
             if (updateDto.Status.HasValue)
                 existingItem.status = updateDto.Status.Value;
+            if (updateDto.Description != null)
+                existingItem.description = updateDto.Description;
 
             var updated = await _studyPlanItemRepository.UpdateStudyPlanItemAsync(existingItem);
             return MapToStudyPlanItemDto(updated);
@@ -95,7 +98,8 @@ namespace JCertPreApplication.Application.Features.StudyPlanItem
                 ItemType = studyPlanItem.itemType,
                 CourseId = studyPlanItem.courseId,
                 TestTemplateTypeId = studyPlanItem.TestTemplateTypeId,
-                Status = studyPlanItem.status
+                Status = studyPlanItem.status,
+                Description = studyPlanItem.description
             };
         }
     }


### PR DESCRIPTION
This pull request introduces support for an optional description field for study plan items, allowing users to add or update a description when creating or modifying a study plan item. Additionally, it adds a check to prevent users from enrolling in personal courses that do not belong to them.

**Study Plan Item Description Support:**

* Added a `Description` property to `StudyPlanItemDto` and `UpdateStudyPlanItemDto` to allow storing and updating descriptions for study plan items. [[1]](diffhunk://#diff-aa57d9e0870d41a5ad64d5424eb62ce3cfe6162e97a403327affe37a588f4bbdR14) [[2]](diffhunk://#diff-966a153b34623ea84bd986c5e2ed115797c848a7e6c76c4d2825d454ae9cd729R12)
* Updated the `IStudyPlanItemService` interface and its implementation to accept a `description` parameter when creating a study plan item, and to map this value appropriately. [[1]](diffhunk://#diff-f496723eb20208fba5c25a5e6f13db66e124f9128ddb87b68498196fbfd39d3bL8-R8) [[2]](diffhunk://#diff-9b13caf7a2c0bce4fe953570424a1d45f2e012475e43e2e62c53f4ea5311a25dL19-R19) [[3]](diffhunk://#diff-9b13caf7a2c0bce4fe953570424a1d45f2e012475e43e2e62c53f4ea5311a25dL33-R34) [[4]](diffhunk://#diff-9b13caf7a2c0bce4fe953570424a1d45f2e012475e43e2e62c53f4ea5311a25dL98-R102)
* Modified the controller `CreateStudyPlanItem` action to accept a `description` parameter and pass it to the service.
* Updated the service's update logic to allow updating the description of a study plan item.

**Enrollment Restrictions:**

* Added a check in `EnrollmentService` to prevent users from enrolling in personal courses that belong to another user, throwing a forbidden error if attempted.